### PR TITLE
Fix metric name for reporterDropped counter.

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/metrics/Metrics.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/metrics/Metrics.java
@@ -174,7 +174,7 @@ public class Metrics {
   public Counter reporterFailure;
 
   @Metric(
-      name = "spans",
+      name = "reporter-spans",
       tags = {@Tag(key = "state", value = "dropped")}
   )
   // Number of spans dropped due to internal queue overflow

--- a/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/reporters/RemoteReporterTest.java
@@ -176,7 +176,7 @@ public class RemoteReporterTest {
     reporter.report(newSpan());
 
     // Then: one or both spans should be dropped
-    Long droppedCount = metricsReporter.counters.get("jaeger.spans.state=dropped");
+    Long droppedCount = metricsReporter.counters.get("jaeger.reporter-spans.state=dropped");
     assertThat(droppedCount, anyOf(equalTo(1L), equalTo(2L)));
   }
 


### PR DESCRIPTION
Based on the go client (https://github.com/uber/jaeger-client-go/blob/master/metrics.go#L63), the metric name is incorrect.