### PR TITLE
Use io.opentracing.GlobalTracer instead of singleton in Configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ ext.junitVersion = '4.12'
 ext.mockitoVersion = '2.2.28'
 ext.junitDataProviderVersion = '1.10.0'
 ext.awaitilityVersion = '3.0.0'
+ext.logbackVersion = '1.2.3'
 
 task wrapper(type: Wrapper) {
     gradleVersion = '4.0'

--- a/jaeger-core/README.md
+++ b/jaeger-core/README.md
@@ -50,6 +50,7 @@ JAEGER_SAMPLER_TYPE | no | The sampler type
 JAEGER_SAMPLER_PARAM | no | The sampler parameter (number)
 JAEGER_SAMPLER_MANAGER_HOST_PORT | no | The host name and port when using the remote controlled sampler
 JAEGER_TAGS | no | A comma separated list of `name = value` tracer level tags, which get added to all reported spans. The value can also refer to an environment variable using the format `${envVarName:default}`, where the `:default` is optional, and identifies a value to be used if the environment variable cannot be found
+JAEGER_DISABLE_GLOBAL_TRACER | no | If set, disables registering the tracer with io.opentracing.GlobalTracer
 
 
 #### Obtaining Tracer via TracerResolver

--- a/jaeger-core/build.gradle
+++ b/jaeger-core/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
     testCompile group: 'com.tngtech.java', name: 'junit-dataprovider', version: junitDataProviderVersion
     testCompile group: 'org.awaitility', name: 'awaitility', version: awaitilityVersion
+    testCompile group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
 
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 }

--- a/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
@@ -188,42 +188,21 @@ public class Configuration {
   }
 
   public synchronized io.opentracing.Tracer getTracer() {
-    if (disableGlobalTracer) {
-      return getLocalTracer();
-    }
-
-    return getGlobalTracer();
-  }
-
-  private io.opentracing.Tracer getGlobalTracer() {
-    if (GlobalTracer.isRegistered()) {
-      return GlobalTracer.get();
-    }
-
-    Tracer tracer = getTracerBuilder().build();
-    GlobalTracer.register(tracer);
-    log.info("Initialized and registered global tracer={}", tracer);
-    return tracer;
-  }
-
-  @Deprecated
-  private io.opentracing.Tracer getLocalTracer() {
     if (tracer != null) {
       return tracer;
     }
 
     tracer = getTracerBuilder().build();
     log.info("Initialized tracer={}", tracer);
+
+    if (!(disableGlobalTracer || GlobalTracer.isRegistered())) {
+      GlobalTracer.register(tracer);
+    }
+
     return tracer;
   }
 
   public synchronized void closeTracer() {
-    if (GlobalTracer.isRegistered()) {
-      Tracer tracer = (Tracer) GlobalTracer.get();
-      tracer.close();
-      return;
-    }
-
     if (tracer != null) {
       tracer.close();
     }

--- a/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
@@ -146,7 +146,7 @@ public class Configuration {
     this(serviceName, samplerConfig, reporterConfig, false);
   }
 
-  public Configuration(
+  private Configuration(
       String serviceName,
       SamplerConfiguration samplerConfig,
       ReporterConfiguration reporterConfig,

--- a/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
@@ -125,8 +125,8 @@ public class Configuration {
   private StatsFactory statsFactory;
 
   /**
-   * Use {@link GlobalTracer} to store the tracer instead of
-   * storing an instance of the tracer in {@link #tracer}.
+   * Don't use {@link GlobalTracer} to store the tracer.
+   * Use the local {@link #tracer} instead.
    */
   private final boolean disableGlobalTracer;
 
@@ -143,7 +143,7 @@ public class Configuration {
       String serviceName,
       SamplerConfiguration samplerConfig,
       ReporterConfiguration reporterConfig) {
-    this(serviceName, samplerConfig, reporterConfig, true);
+    this(serviceName, samplerConfig, reporterConfig, false);
   }
 
   public Configuration(
@@ -177,7 +177,7 @@ public class Configuration {
         getProperty(JAEGER_SERVICE_NAME),
         SamplerConfiguration.fromEnv(),
         ReporterConfiguration.fromEnv(),
-        Boolean.valueOf(getProperty(JAEGER_DISABLE_GLOBAL_TRACER)));
+        getPropertyAsBoolean(JAEGER_DISABLE_GLOBAL_TRACER));
   }
 
   public Tracer.Builder getTracerBuilder() {
@@ -451,11 +451,7 @@ public class Configuration {
   }
 
   private static Boolean getPropertyAsBoolean(String name) {
-    String value = getProperty(name);
-    if (value != null) {
-      return Boolean.valueOf(value);
-    }
-    return null;
+    return Boolean.valueOf(getProperty(name));
   }
 
   private static Map<String, String> tracerTagsFromEnv() {

--- a/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
@@ -173,19 +173,11 @@ public class Configuration {
   }
 
   public static Configuration fromEnv() {
-    boolean disableGlobalTracer = getPropertyAsBool(JAEGER_DISABLE_GLOBAL_TRACER);
-    if (GlobalTracer.isRegistered() && !disableGlobalTracer) {
-      throw new IllegalStateException(
-          String.format(
-              "There is already a current global Tracer registered. "
-                  + "Set %s to disable automatic registration.",
-              JAEGER_DISABLE_GLOBAL_TRACER));
-    }
     return new Configuration(
         getProperty(JAEGER_SERVICE_NAME),
         SamplerConfiguration.fromEnv(),
         ReporterConfiguration.fromEnv(),
-        disableGlobalTracer);
+        getPropertyAsBool(JAEGER_DISABLE_GLOBAL_TRACER));
   }
 
   public Tracer.Builder getTracerBuilder() {
@@ -203,7 +195,7 @@ public class Configuration {
     tracer = getTracerBuilder().build();
     log.info("Initialized tracer={}", tracer);
 
-    if (!(disableGlobalTracer || GlobalTracer.isRegistered())) {
+    if (!disableGlobalTracer) {
       GlobalTracer.register(tracer);
     }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
@@ -173,11 +173,19 @@ public class Configuration {
   }
 
   public static Configuration fromEnv() {
+    boolean disableGlobalTracer = getPropertyAsBool(JAEGER_DISABLE_GLOBAL_TRACER);
+    if (GlobalTracer.isRegistered() && !disableGlobalTracer) {
+      throw new IllegalStateException(
+          String.format(
+              "There is already a current global Tracer registered. "
+                  + "Set %s to disable automatic registration.",
+              JAEGER_DISABLE_GLOBAL_TRACER));
+    }
     return new Configuration(
         getProperty(JAEGER_SERVICE_NAME),
         SamplerConfiguration.fromEnv(),
         ReporterConfiguration.fromEnv(),
-        getPropertyAsBoolean(JAEGER_DISABLE_GLOBAL_TRACER));
+        disableGlobalTracer);
   }
 
   public Tracer.Builder getTracerBuilder() {
@@ -342,7 +350,7 @@ public class Configuration {
 
     public static ReporterConfiguration fromEnv() {
       return new ReporterConfiguration(
-          getPropertyAsBoolean(JAEGER_REPORTER_LOG_SPANS),
+          getPropertyAsBool(JAEGER_REPORTER_LOG_SPANS),
           getProperty(JAEGER_AGENT_HOST),
           getPropertyAsInt(JAEGER_AGENT_PORT),
           getPropertyAsInt(JAEGER_REPORTER_FLUSH_INTERVAL),
@@ -429,7 +437,12 @@ public class Configuration {
     return null;
   }
 
-  private static Boolean getPropertyAsBoolean(String name) {
+  /**
+   * Gets the system property defined by the name , and returns a boolean value represented by
+   * the name. This method defaults to returning false for a name that doesn't exist.
+   * @param name The name of the system property
+   */
+  private static boolean getPropertyAsBool(String name) {
     return Boolean.valueOf(getProperty(name));
   }
 

--- a/jaeger-core/src/test/java/com/uber/jaeger/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/ConfigurationTest.java
@@ -61,7 +61,7 @@ public class ConfigurationTest {
 
     System.clearProperty(TEST_PROPERTY);
 
-    // Hack to reset opentracing's global tracer
+    // Reset opentracing's global tracer
     Field field = GlobalTracer.class.getDeclaredField("tracer");
     field.setAccessible(true);
     field.set(null, NoopTracerFactory.create());
@@ -72,6 +72,15 @@ public class ConfigurationTest {
     System.setProperty(Configuration.JAEGER_SERVICE_NAME, "Test");
     assertNotNull(Configuration.fromEnv().getTracer());
     assertTrue(GlobalTracer.isRegistered());
+  }
+
+  @Test (expected = IllegalStateException.class)
+  public void testFromEnvWithoutDisabledTracer() {
+    System.setProperty(Configuration.JAEGER_SERVICE_NAME, "Test");
+    assertNotNull(Configuration.fromEnv().getTracer());
+    assertTrue(GlobalTracer.isRegistered());
+
+    Configuration.fromEnv().getTracer();
   }
 
   @Test
@@ -85,7 +94,7 @@ public class ConfigurationTest {
   @Test
   public void testDefaultGlobalTracer() {
     Configuration config = new Configuration("Test");
-    config.getTracer();
+    assertNotNull(config.getTracer());
     assertTrue(GlobalTracer.isRegistered());
   }
 

--- a/jaeger-core/src/test/java/com/uber/jaeger/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/ConfigurationTest.java
@@ -83,6 +83,13 @@ public class ConfigurationTest {
   }
 
   @Test
+  public void testDefaultGlobalTracer() {
+    Configuration config = new Configuration("Test");
+    config.getTracer();
+    assertTrue(GlobalTracer.isRegistered());
+  }
+
+  @Test
   public void testSamplerConst() {
     System.setProperty(Configuration.JAEGER_SAMPLER_TYPE, ConstSampler.TYPE);
     System.setProperty(Configuration.JAEGER_SAMPLER_PARAM, "1");

--- a/jaeger-crossdock/src/test/java/com/uber/jaeger/crossdock/resources/behavior/http/TraceBehaviorResourceTest.java
+++ b/jaeger-crossdock/src/test/java/com/uber/jaeger/crossdock/resources/behavior/http/TraceBehaviorResourceTest.java
@@ -38,7 +38,10 @@ import com.uber.jaeger.crossdock.api.TraceResponse;
 import com.uber.jaeger.crossdock.resources.behavior.TraceBehavior;
 import com.uber.jaeger.crossdock.resources.behavior.tchannel.TChannelServer;
 import com.uber.tchannel.api.TChannel.Builder;
+import io.opentracing.NoopTracerFactory;
 import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracer;
+import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -94,8 +97,12 @@ public class TraceBehaviorResourceTest {
   }
 
   @After
-  public void tearDown() {
+  public void tearDown() throws Exception {
     server.shutdown();
+    // Reset opentracing's global tracer
+    Field field = GlobalTracer.class.getDeclaredField("tracer");
+    field.setAccessible(true);
+    field.set(null, NoopTracerFactory.create());
   }
 
   @Test


### PR DESCRIPTION
- Register the tracer created by com.uber.jaeger.Configuration#getTracer
  with opentracing's GlobalTracer mechanism so that opentracing instrumentations
  may find it.

- Disable the lazily loaded singleton field by default.

This is a prerequisite for #257 