### PR TITLE
Make gradle use travis/docker-thrift/thrift script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,6 @@ cache:
 before_install:
 - ./travis/prepare-signing.sh $encrypted_677f232983c0_key $encrypted_677f232983c0_iv
 - if [ "$CROSSDOCK" == true ]; then bash ./travis/install-crossdock-deps.sh ; fi
-- sudo rm -rf /usr/local/bin/thrift
-- sudo cp travis/docker-thrift/thrift /usr/local/bin/
 script:
 - if [ "$TESTS" == true ]; then make test ; else echo 'skipping tests'; fi
 - if [ "$COVERAGE" == true ]; then ./gradlew codeCoverageReport ; else echo 'skipping coverage'; fi

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import java.util.regex.Pattern
 
 plugins {
-    id "org.jruyi.thrift" version "0.3.1"
+    id "org.jruyi.thrift" version "0.4.0"
     id "jacoco"
     id "com.github.hierynomus.license" version "0.14.0"
     id 'com.github.sherter.google-java-format' version '0.3.2'

--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -18,6 +18,7 @@ dependencies {
  * `brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/56d8c1eba1e5ac30290dd0c486f4bba37f821e42/Formula/thrift.rb`
  */
 compileThrift {
+    thriftExecutable "${projectDir}/../travis/docker-thrift/thrift"
     sourceDir "${projectDir}/../idl/thrift"
     outputDir 'src/main/gen-java'
     generator 'java', 'private-members'

--- a/travis/docker-thrift/thrift
+++ b/travis/docker-thrift/thrift
@@ -18,4 +18,6 @@ set -e
 ${THRIFT} $args
 
 # docker command runs as root, but we need normal permissions
-sudo chmod -R 0777 ${pwd}/jaeger-thrift/src/main/gen-java
+if test ! -r ${pwd}/jaeger-thrift/src/main/gen-java; then
+  sudo chmod -R 0777 ${pwd}/jaeger-thrift/src/main/gen-java
+fi


### PR DESCRIPTION
Right now the thrift plugin uses the default location of thrift compiler, which forces us to override the compiler in Travis, and locally you just hope that you have the correct version (0.9.2) installed.

This change tells the plugin to use the wrapper script we have in `travis/docker-thrift/thrift` that uses a thrift compiler from a Docker image.

It means in order to build the project locally one must have Docker installed.