### PR TITLE
Use Mockito's timeout for test

### DIFF
--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/RemoteControlledSamplerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/RemoteControlledSamplerTest.java
@@ -17,7 +17,7 @@ package com.uber.jaeger.samplers;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -108,9 +108,8 @@ public class RemoteControlledSamplerTest {
     undertest = new RemoteControlledSampler(SERVICE_NAME, samplingManager, perOperationSampler, metrics);
 
     undertest.updateSampler();
-    Thread.sleep(20);
     //updateSampler is hit once automatically because of the pollTimer
-    verify(perOperationSampler, times(2)).update(parameters);
+    verify(perOperationSampler, timeout(2000).times(2)).update(parameters);
   }
 
   @Test


### PR DESCRIPTION
- use Mockito's timeout instead of Thread.sleep
- Fixes #268

Signed-off-by: Prithvi Raj <p.r@uber.com>