### PR TITLE
Update errorprone and lombok and fix warnings and errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id "com.github.hierynomus.license" version "0.14.0"
     id 'com.github.sherter.google-java-format' version '0.3.2'
     id "com.github.johnrengelman.shadow" version "2.0.1"
-    id "net.ltgt.errorprone" version "0.0.10"
+    id "net.ltgt.errorprone" version "0.0.12"
     id 'ru.vyarus.animalsniffer' version '1.3.0'
     id 'io.codearte.nexus-staging' version '0.11.0'
 }
@@ -167,6 +167,10 @@ configure(subprojects.findAll {it.name != 'jaeger-thrift'}) {
    dependencies {
      errorprone 'com.google.errorprone:error_prone_core:2.1.1'
    }
+    tasks.withType(JavaCompile) {
+        // These are disabled because of a bug with errorprone. See https://github.com/google/error-prone/issues/750
+        options.compilerArgs += [ '-Xep:NestedInstanceOfConditions:OFF',  '-Xep:InstanceOfAndCastMatchWrongType:OFF' ]
+    }
 }
 
 def getVersionForBuild() {

--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ subprojects {
     }
 
     dependencies {
-        compileOnly 'org.projectlombok:lombok:1.16.12'
+        compileOnly 'org.projectlombok:lombok:1.16.18'
         compileOnly 'org.codehaus.mojo:animal-sniffer-annotations:1.15'
     }
 
@@ -165,7 +165,7 @@ task printVersion {
 configure(subprojects.findAll {it.name != 'jaeger-thrift'}) {
    apply plugin: 'net.ltgt.errorprone'
    dependencies {
-     errorprone 'com.google.errorprone:error_prone_core:2.0.15'
+     errorprone 'com.google.errorprone:error_prone_core:2.1.1'
    }
 }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -268,7 +268,7 @@ public class Tracer implements io.opentracing.Tracer, Closeable {
 
       byte flags = 0;
       if (debugId != null) {
-        flags |= SpanContext.flagSampled | SpanContext.flagDebug;
+        flags = (byte) (flags | SpanContext.flagSampled | SpanContext.flagDebug);
         tags.put(Constants.DEBUG_ID_HEADER_KEY, debugId);
         metrics.traceStartedSampled.inc(1);
       } else {

--- a/jaeger-core/src/test/java/com/uber/jaeger/samplers/GuaranteedThroughputSamplerTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/samplers/GuaranteedThroughputSamplerTest.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.assertTrue;
 
 import com.uber.jaeger.Constants;
 import java.util.Map;
+
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,6 +32,7 @@ public class GuaranteedThroughputSamplerTest {
 
   private GuaranteedThroughputSampler undertest;
 
+  @After
   public void tearDown() {
     undertest.close();
   }

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/JerseyServer.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/JerseyServer.java
@@ -36,9 +36,11 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import org.apache.log4j.BasicConfigurator;
+import org.glassfish.grizzly.GrizzlyFuture;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.http.server.NetworkListener;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
@@ -117,8 +119,8 @@ public class JerseyServer {
         .register(JacksonFeature.class);
   }
 
-  public void shutdown() {
-    server.shutdown();
+  public void shutdown() throws ExecutionException, InterruptedException {
+    server.shutdown().get();
   }
 
   public Tracer getTracer() {

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/JerseyServer.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/JerseyServer.java
@@ -40,7 +40,6 @@ import java.util.concurrent.ExecutionException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import org.apache.log4j.BasicConfigurator;
-import org.glassfish.grizzly.GrizzlyFuture;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.grizzly.http.server.NetworkListener;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/tchannel/TChannelServer.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/resources/behavior/tchannel/TChannelServer.java
@@ -18,6 +18,7 @@ import com.uber.jaeger.context.TracingUtils;
 import com.uber.jaeger.crossdock.resources.behavior.TraceBehavior;
 import com.uber.tchannel.api.TChannel;
 import com.uber.tchannel.tracing.TracingContext;
+import io.netty.channel.ChannelFuture;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import java.util.EmptyStackException;
@@ -45,7 +46,10 @@ public class TChannelServer {
 
   public void start() throws InterruptedException {
     // listen for incoming connections
-    server.listen().channel().closeFuture();
+    ChannelFuture serverFuture = server.listen().awaitUninterruptibly();
+    if (!serverFuture.isSuccess()) {
+      throw new RuntimeException("Server future unsuccessful");
+    }
   }
 
   public void shutdown() {

--- a/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
+++ b/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
@@ -55,6 +55,7 @@ public class JerseyServerFilterTest extends JerseyTest {
     return resourceConfig;
   }
 
+  @Override
   @After
   public void tearDown() throws Exception {
     super.tearDown();


### PR DESCRIPTION
    - Update errorprone to 2.1.1
    - Update lombok to 1.16.18
    - Disable the InstanceOfAndCastMatchWrongType and NestedInstanceOfConditions checks to ensure compatibility with lombok. See https://github.com/google/error-prone/issues/750