### PR TITLE
Add ability to supply custom span id

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -338,7 +338,7 @@ public class Tracer implements io.opentracing.Tracer, Closeable {
 
       return new SpanContext(
           preferredReference.getTraceId(),
-          Utils.uniqueId(),
+          this.id,
           preferredReference.getSpanId(),
           // should we do OR across passed references?
           preferredReference.getFlags(),

--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -148,6 +148,14 @@ public class Tracer implements io.opentracing.Tracer, Closeable {
     return new SpanBuilder(operationName);
   }
 
+  /**
+   * For systems that are currently migrating to Jaeger and which are generating their own <b>unique</b> identifier,
+   * this method can be used to help ease the transition.
+   */
+  public io.opentracing.Tracer.SpanBuilder buildSpan(String operationName, long id) {
+    return new SpanBuilder(operationName, id);
+  }
+
   @Override
   public <T> void inject(io.opentracing.SpanContext spanContext, Format<T> format, T carrier) {
     Injector<T> injector = registry.getInjector(format);
@@ -198,8 +206,16 @@ public class Tracer implements io.opentracing.Tracer, Closeable {
     private final Map<String, Object> tags = new HashMap<String, Object>();
     private boolean ignoreActiveSpan = false;
 
-    SpanBuilder(String operationName) {
+    //The unique id for the span
+    private final long id;
+
+    SpanBuilder(String operationName, long id) {
       this.operationName = operationName;
+      this.id = id;
+    }
+
+    SpanBuilder(String operationName) {
+      this(operationName, Utils.uniqueId());
     }
 
     @Override
@@ -264,8 +280,6 @@ public class Tracer implements io.opentracing.Tracer, Closeable {
     }
 
     private SpanContext createNewContext(String debugId) {
-      long id = Utils.uniqueId();
-
       byte flags = 0;
       if (debugId != null) {
         flags |= SpanContext.flagSampled | SpanContext.flagDebug;


### PR DESCRIPTION
This PR allows users of Jaeger to supply a custom span id.
In order to ease adoption for Jaeger it is beneficial to allow users to potentially supply their own id.