### PR TITLE
Configuration enabled support for B3 trace context propagation in add…

### DIFF
--- a/jaeger-b3/src/main/java/com/uber/jaeger/propagation/b3/B3TextMapCodec.java
+++ b/jaeger-b3/src/main/java/com/uber/jaeger/propagation/b3/B3TextMapCodec.java
@@ -14,15 +14,6 @@
 
 package com.uber.jaeger.propagation.b3;
 
-import com.uber.jaeger.SpanContext;
-import com.uber.jaeger.propagation.Extractor;
-import com.uber.jaeger.propagation.HexCodec;
-import com.uber.jaeger.propagation.Injector;
-import com.uber.jaeger.propagation.TextMapCodec;
-
-import io.opentracing.propagation.TextMap;
-import java.util.Map;
-
 /**
  * This format is compatible with other trace libraries such as Brave, Wingtips, zipkin-js, etc.
  *
@@ -40,22 +31,9 @@ import java.util.Map;
  * <p>
  * See <a href="http://zipkin.io/pages/instrumenting.html">Instrumenting a Library</a>
  */
-public final class B3TextMapCodec extends TextMapCodec {
+public final class B3TextMapCodec extends com.uber.jaeger.propagation.B3TextMapCodec {
 
-  static final String TRACE_ID_NAME = TextMapCodec.TRACE_ID_NAME;
-  static final String SPAN_ID_NAME = TextMapCodec.SPAN_ID_NAME;
+  static final String TRACE_ID_NAME = com.uber.jaeger.propagation.B3TextMapCodec.TRACE_ID_NAME;
+  static final String SPAN_ID_NAME = com.uber.jaeger.propagation.B3TextMapCodec.SPAN_ID_NAME;
 
-  public B3TextMapCodec() {
-    super(true);
-  }
-
-  @Override
-  public void inject(SpanContext spanContext, TextMap carrier) {
-    super.injectB3(spanContext, carrier);
-  }
-
-  @Override
-  public SpanContext extract(TextMap carrier) {
-    return super.extractB3(carrier);
-  }
 }

--- a/jaeger-b3/src/main/java/com/uber/jaeger/propagation/b3/B3TextMapCodec.java
+++ b/jaeger-b3/src/main/java/com/uber/jaeger/propagation/b3/B3TextMapCodec.java
@@ -15,7 +15,7 @@
 package com.uber.jaeger.propagation.b3;
 
 /**
- * This format is compatible with other trace libraries such as Brave, Wingtips, zipkin-js, etc.
+ * This format is compatible with other Zipkin based trace libraries such as Brave, Wingtips, zipkin-js, etc.
  *
  * <p>
  * Example usage:

--- a/jaeger-b3/src/test/java/com/uber/jaeger/propagation/b3/B3TextMapCodecTest.java
+++ b/jaeger-b3/src/test/java/com/uber/jaeger/propagation/b3/B3TextMapCodecTest.java
@@ -26,6 +26,8 @@ import com.github.kristofa.brave.http.HttpClientRequestAdapter;
 import com.github.kristofa.brave.http.HttpServerRequest;
 import com.github.kristofa.brave.http.HttpServerRequestAdapter;
 import com.uber.jaeger.SpanContext;
+import com.uber.jaeger.propagation.HexCodec;
+
 import io.opentracing.propagation.TextMap;
 import java.net.URI;
 import java.util.Iterator;

--- a/jaeger-b3/src/test/java/com/uber/jaeger/propagation/b3/B3TextMapCodecTest.java
+++ b/jaeger-b3/src/test/java/com/uber/jaeger/propagation/b3/B3TextMapCodecTest.java
@@ -26,7 +26,6 @@ import com.github.kristofa.brave.http.HttpClientRequestAdapter;
 import com.github.kristofa.brave.http.HttpServerRequest;
 import com.github.kristofa.brave.http.HttpServerRequestAdapter;
 import com.uber.jaeger.SpanContext;
-import com.uber.jaeger.propagation.HexCodec;
 
 import io.opentracing.propagation.TextMap;
 import java.net.URI;
@@ -51,21 +50,6 @@ public class B3TextMapCodecTest {
     assertEquals(0, context.getParentId()); // parentID==0 means root span
     assertEquals(1, context.getSpanId());
     assertEquals(1, context.getFlags()); // sampled
-  }
-
-  @Test
-  public void downgrades128BitTraceIdToLower64Bits() throws Exception {
-    String hex128Bits = "463ac35c9f6413ad48485a3953bb6124";
-    String lower64Bits = "48485a3953bb6124";
-
-    DelegatingTextMap textMap = new DelegatingTextMap();
-    textMap.put(TRACE_ID_NAME, hex128Bits);
-    textMap.put(SPAN_ID_NAME, lower64Bits);
-
-    SpanContext context = b3Codec.extract(textMap);
-
-    assertEquals(HexCodec.lowerHexToUnsignedLong(lower64Bits), context.getTraceId());
-    assertEquals(HexCodec.lowerHexToUnsignedLong(lower64Bits), context.getSpanId());
   }
 
   @Test

--- a/jaeger-core/README.md
+++ b/jaeger-core/README.md
@@ -47,7 +47,7 @@ JAEGER_ENDPOINT | no | The traces endpoint, in case the client should connect di
 JAEGER_AUTH_TOKEN | no | Authentication Token to send as "Bearer" to the endpoint
 JAEGER_USER | no | Username to send as part of "Basic" authentication to the endpoint
 JAEGER_PASSWORD | no | Password to send as part of "Basic" authentication to the endpoint
-JAEGER_PROPAGATION | no | Comma separated list of formats to use for propagating the trace context. Default will the standard Jaeger format. Valid values are **jaeger** and **b3**
+JAEGER_PROPAGATION | no | Comma separated list of formats to use for propagating the trace context. Defaults to the standard Jaeger format. Valid values are **jaeger** and **b3**
 JAEGER_REPORTER_LOG_SPANS | no | Whether the reporter should also log the spans
 JAEGER_REPORTER_MAX_QUEUE_SIZE | no | The reporter's maximum queue size
 JAEGER_REPORTER_FLUSH_INTERVAL | no | The reporter's flush interval (ms)

--- a/jaeger-core/README.md
+++ b/jaeger-core/README.md
@@ -43,6 +43,7 @@ Property | Required | Description
 JAEGER_SERVICE_NAME | yes | The service name
 JAEGER_AGENT_HOST | no | The hostname for communicating with agent via UDP
 JAEGER_AGENT_PORT | no | The port for communicating with agent via UDP
+JAEGER_B3_CODEC | false | Whether to support B3 trace context propagation headers
 JAEGER_ENDPOINT | no | The traces endpoint, in case the client should connect directly to the Collector, like http://jaeger-collector:14268/api/traces
 JAEGER_AUTH_TOKEN | no | Authentication Token to send as "Bearer" to the endpoint
 JAEGER_USER | no | Username to send as part of "Basic" authentication to the endpoint

--- a/jaeger-core/README.md
+++ b/jaeger-core/README.md
@@ -43,11 +43,11 @@ Property | Required | Description
 JAEGER_SERVICE_NAME | yes | The service name
 JAEGER_AGENT_HOST | no | The hostname for communicating with agent via UDP
 JAEGER_AGENT_PORT | no | The port for communicating with agent via UDP
-JAEGER_B3_CODEC | false | Whether to support B3 trace context propagation headers
 JAEGER_ENDPOINT | no | The traces endpoint, in case the client should connect directly to the Collector, like http://jaeger-collector:14268/api/traces
 JAEGER_AUTH_TOKEN | no | Authentication Token to send as "Bearer" to the endpoint
 JAEGER_USER | no | Username to send as part of "Basic" authentication to the endpoint
 JAEGER_PASSWORD | no | Password to send as part of "Basic" authentication to the endpoint
+JAEGER_PROPAGATION | no | Comma separated list of formats to use for propagating the trace context. Default will the standard Jaeger format. Valid values are **jaeger** and **b3**
 JAEGER_REPORTER_LOG_SPANS | no | Whether the reporter should also log the spans
 JAEGER_REPORTER_MAX_QUEUE_SIZE | no | The reporter's maximum queue size
 JAEGER_REPORTER_FLUSH_INTERVAL | no | The reporter's flush interval (ms)

--- a/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
@@ -375,10 +375,10 @@ public class Configuration {
       if (!codecs.isEmpty()) {
         // Replace existing TEXT_MAP and HTTP_HEADERS codec with one that also includes the
         // list of configured codecs
-        TextMapCodec textMapCodec = TextMapCodec.builder().withUrlEncoding(false).withCodec(codecs).build();
+        TextMapCodec textMapCodec = TextMapCodec.builder().withUrlEncoding(false).withCodecs(codecs).build();
         builder.registerInjector(Format.Builtin.TEXT_MAP, textMapCodec);
         builder.registerExtractor(Format.Builtin.TEXT_MAP, textMapCodec);
-        TextMapCodec httpCodec = TextMapCodec.builder().withUrlEncoding(true).withCodec(codecs).build();
+        TextMapCodec httpCodec = TextMapCodec.builder().withUrlEncoding(true).withCodecs(codecs).build();
         builder.registerInjector(Format.Builtin.HTTP_HEADERS, httpCodec);
         builder.registerExtractor(Format.Builtin.HTTP_HEADERS, httpCodec);
       }

--- a/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
@@ -18,6 +18,7 @@ import com.uber.jaeger.metrics.Metrics;
 import com.uber.jaeger.metrics.NullStatsReporter;
 import com.uber.jaeger.metrics.StatsFactory;
 import com.uber.jaeger.metrics.StatsFactoryImpl;
+import com.uber.jaeger.propagation.B3TextMapCodec;
 import com.uber.jaeger.propagation.TextMapCodec;
 import com.uber.jaeger.reporters.CompositeReporter;
 import com.uber.jaeger.reporters.LoggingReporter;
@@ -224,10 +225,10 @@ public class Configuration {
         reporter, sampler).withMetrics(metrics).withTags(tracerTagsFromEnv());
     if (b3codec) {
       // Replace the codec with a B3 enabled instance
-      TextMapCodec textMapCodec = TextMapCodec.builder().withUrlEncoding(false).withB3(b3codec).build();
+      TextMapCodec textMapCodec = TextMapCodec.builder().withUrlEncoding(false).withCodec(new B3TextMapCodec()).build();
       builder.registerInjector(Format.Builtin.TEXT_MAP, textMapCodec);
       builder.registerExtractor(Format.Builtin.TEXT_MAP, textMapCodec);
-      TextMapCodec httpCodec = TextMapCodec.builder().withUrlEncoding(true).withB3(b3codec).build();
+      TextMapCodec httpCodec = TextMapCodec.builder().withUrlEncoding(true).withCodec(new B3TextMapCodec()).build();
       builder.registerInjector(Format.Builtin.HTTP_HEADERS, httpCodec);
       builder.registerExtractor(Format.Builtin.HTTP_HEADERS, httpCodec);
     }

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/B3TextMapCodec.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/B3TextMapCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Uber Technologies, Inc
+ * Copyright (c) 2017, Uber Technologies, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/B3TextMapCodec.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/B3TextMapCodec.java
@@ -19,7 +19,7 @@ import io.opentracing.propagation.TextMap;
 import java.util.Map;
 
 /**
- * This format is compatible with other trace libraries such as Brave, Wingtips, zipkin-js, etc.
+ * This format is compatible with other Zipkin based trace libraries such as Brave, Wingtips, zipkin-js, etc.
  *
  * <p>
  * Example usage:

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/B3TextMapCodec.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/B3TextMapCodec.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2016, Uber Technologies, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.uber.jaeger.propagation;
+
+import com.uber.jaeger.SpanContext;
+import io.opentracing.propagation.TextMap;
+import java.util.Map;
+
+/**
+ * This format is compatible with other trace libraries such as Brave, Wingtips, zipkin-js, etc.
+ *
+ * <p>
+ * Example usage:
+ *
+ * <pre>{@code
+ * b3Codec = new B3TextMapCodec();
+ * tracer = new Tracer.Builder(serviceName, reporter, sampler)
+ *                    .registerInjector(Format.Builtin.HTTP_HEADERS, b3Codec)
+ *                    .registerExtractor(Format.Builtin.HTTP_HEADERS, b3Codec)
+ *                    ...
+ * }</pre>
+ *
+ * <p>
+ * See <a href="http://zipkin.io/pages/instrumenting.html">Instrumenting a Library</a>
+ */
+public class B3TextMapCodec implements Codec<TextMap> {
+  protected static final String TRACE_ID_NAME = "X-B3-TraceId";
+  protected static final String SPAN_ID_NAME = "X-B3-SpanId";
+  protected static final String PARENT_SPAN_ID_NAME = "X-B3-ParentSpanId";
+  protected static final String SAMPLED_NAME = "X-B3-Sampled";
+  protected static final String FLAGS_NAME = "X-B3-Flags";
+  // NOTE: uber's flags aren't the same as B3/Finagle ones
+  protected static final byte SAMPLED_FLAG = 1;
+  protected static final byte DEBUG_FLAG = 2;
+
+  @Override
+  public void inject(SpanContext spanContext, TextMap carrier) {
+    carrier.put(TRACE_ID_NAME, HexCodec.toLowerHex(spanContext.getTraceId()));
+    if (spanContext.getParentId() != 0L) { // Conventionally, parent id == 0 means the root span
+      carrier.put(PARENT_SPAN_ID_NAME, HexCodec.toLowerHex(spanContext.getParentId()));
+    }
+    carrier.put(SPAN_ID_NAME, HexCodec.toLowerHex(spanContext.getSpanId()));
+    carrier.put(SAMPLED_NAME, spanContext.isSampled() ? "1" : "0");
+    if (spanContext.isDebug()) {
+      carrier.put(FLAGS_NAME, "1");
+    }
+  }
+
+  @Override
+  public SpanContext extract(TextMap carrier) {
+    Long traceId = null;
+    Long spanId = null;
+    long parentId = 0L; // Conventionally, parent id == 0 means the root span
+    byte flags = 0;
+    for (Map.Entry<String, String> entry : carrier) {
+      if (entry.getKey().equalsIgnoreCase(SAMPLED_NAME)) {
+        String value = entry.getValue();
+        if ("1".equals(value) || "true".equalsIgnoreCase(value)) {
+          flags |= SAMPLED_FLAG;
+        }
+      } else if (entry.getKey().equalsIgnoreCase(TRACE_ID_NAME)) {
+        traceId = HexCodec.lowerHexToUnsignedLong(entry.getValue());
+      } else if (entry.getKey().equalsIgnoreCase(PARENT_SPAN_ID_NAME)) {
+        parentId = HexCodec.lowerHexToUnsignedLong(entry.getValue());
+      } else if (entry.getKey().equalsIgnoreCase(SPAN_ID_NAME)) {
+        spanId = HexCodec.lowerHexToUnsignedLong(entry.getValue());
+      } else if (entry.getKey().equalsIgnoreCase(FLAGS_NAME)) {
+        if (entry.getValue().equals("1")) {
+          flags |= DEBUG_FLAG;
+        }
+      }
+    }
+
+    if (traceId != null && spanId != null) {
+      return new SpanContext(traceId, spanId, parentId, flags);
+    }
+    return null;
+  }
+}

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/Codec.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/Codec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Jaeger Tracing Authors
+ * Copyright (c) 2017, The Jaeger Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/Codec.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/Codec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Uber Technologies, Inc
+ * Copyright (c) 2017, Jaeger Tracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/Codec.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/Codec.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016, Uber Technologies, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.uber.jaeger.propagation;
+
+public interface Codec<T> extends Injector<T>, Extractor<T> {
+}

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/CompositeCodec.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/CompositeCodec.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2017, The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.uber.jaeger.propagation;
+
+import com.uber.jaeger.SpanContext;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class CompositeCodec<T> implements Codec<T> {
+
+  private final java.util.List<Codec<T>> codecs;
+
+  public CompositeCodec(List<Codec<T>> codecs) {
+    this.codecs = new LinkedList<Codec<T>>(codecs);
+  }
+
+  @Override
+  public void inject(SpanContext spanContext, T carrier) {
+    for (Codec<T> codec : codecs) {
+      codec.inject(spanContext, carrier);
+    }
+  }
+
+  @Override
+  public SpanContext extract(T carrier) {
+    for (Codec<T> codec : codecs) {
+      SpanContext context = codec.extract(carrier);
+      if (context != null) {
+        return context;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buffer = new StringBuilder();
+    for (Codec<T> codec : codecs) {
+      if (buffer.length() > 0) {
+        buffer.append(" : ");
+      }
+      buffer.append(codec.toString());
+    }
+    return buffer.toString();
+  }
+
+}

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/HexCodec.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/HexCodec.java
@@ -21,7 +21,7 @@ public final class HexCodec {
    * Parses a 1 to 32 character lower-hex string with no prefix into an unsigned long, tossing any
    * bits higher than 64.
    */
-  public static long lowerHexToUnsignedLong(String lowerHex) {
+  static long lowerHexToUnsignedLong(String lowerHex) {
     int length = lowerHex.length();
     if (length < 1 || length > 32) {
       throw isntLowerHexLong(lowerHex);
@@ -75,7 +75,7 @@ public final class HexCodec {
   /**
    * Inspired by {@code okio.Buffer.writeLong}
    */
-  public static String toLowerHex(long v) {
+  static String toLowerHex(long v) {
     char[] data = new char[16];
     writeHexLong(data, 0, v);
     return new String(data);

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/HexCodec.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/HexCodec.java
@@ -15,7 +15,7 @@
 package com.uber.jaeger.propagation;
 
 // copy/pasted from brave.internal.HexCodec 4.1.1 to avoid build complexity
-public final class HexCodec {
+final class HexCodec {
 
   /**
    * Parses a 1 to 32 character lower-hex string with no prefix into an unsigned long, tossing any

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/HexCodec.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/HexCodec.java
@@ -12,16 +12,16 @@
  * the License.
  */
 
-package com.uber.jaeger.propagation.b3;
+package com.uber.jaeger.propagation;
 
 // copy/pasted from brave.internal.HexCodec 4.1.1 to avoid build complexity
-final class HexCodec {
+public final class HexCodec {
 
   /**
    * Parses a 1 to 32 character lower-hex string with no prefix into an unsigned long, tossing any
    * bits higher than 64.
    */
-  static long lowerHexToUnsignedLong(String lowerHex) {
+  public static long lowerHexToUnsignedLong(String lowerHex) {
     int length = lowerHex.length();
     if (length < 1 || length > 32) {
       throw isntLowerHexLong(lowerHex);
@@ -75,7 +75,7 @@ final class HexCodec {
   /**
    * Inspired by {@code okio.Buffer.writeLong}
    */
-  static String toLowerHex(long v) {
+  public static String toLowerHex(long v) {
     char[] data = new char[16];
     writeHexLong(data, 0, v);
     return new String(data);

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/TextMapCodec.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/TextMapCodec.java
@@ -23,6 +23,7 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -187,6 +188,14 @@ public class TextMapCodec implements Codec<TextMap> {
         this.codecs = new LinkedList<Codec<TextMap>>();
       }
       this.codecs.add(codec);
+      return this;
+    }
+
+    public Builder withCodec(List<Codec<TextMap>> codecs) {
+      if (this.codecs == null) {
+        this.codecs = new LinkedList<Codec<TextMap>>();
+      }
+      this.codecs.addAll(codecs);
       return this;
     }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/TextMapCodec.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/TextMapCodec.java
@@ -191,7 +191,7 @@ public class TextMapCodec implements Codec<TextMap> {
       return this;
     }
 
-    public Builder withCodec(List<Codec<TextMap>> codecs) {
+    public Builder withCodecs(List<Codec<TextMap>> codecs) {
       if (this.codecs == null) {
         this.codecs = new LinkedList<Codec<TextMap>>();
       }

--- a/jaeger-core/src/main/java/com/uber/jaeger/propagation/TextMapCodec.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/propagation/TextMapCodec.java
@@ -16,6 +16,7 @@ package com.uber.jaeger.propagation;
 
 import com.uber.jaeger.Constants;
 import com.uber.jaeger.SpanContext;
+
 import io.opentracing.propagation.TextMap;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -35,6 +36,15 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
    */
   private static final String BAGGAGE_KEY_PREFIX = "uberctx-";
 
+  protected static final String TRACE_ID_NAME = "X-B3-TraceId";
+  protected static final String SPAN_ID_NAME = "X-B3-SpanId";
+  protected static final String PARENT_SPAN_ID_NAME = "X-B3-ParentSpanId";
+  protected static final String SAMPLED_NAME = "X-B3-Sampled";
+  protected static final String FLAGS_NAME = "X-B3-Flags";
+  // NOTE: uber's flags aren't the same as B3/Finagle ones
+  protected static final byte SAMPLED_FLAG = 1;
+  protected static final byte DEBUG_FLAG = 2;
+
   private static final PrefixedKeys keys = new PrefixedKeys();
 
   private final String contextKey;
@@ -42,6 +52,8 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
   private final String baggagePrefix;
 
   private final boolean urlEncoding;
+
+  private final boolean b3;
 
   public TextMapCodec(boolean urlEncoding) {
     this(builder().withUrlEncoding(urlEncoding));
@@ -51,6 +63,7 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
     this.urlEncoding = builder.urlEncoding;
     this.contextKey = builder.spanContextKey;
     this.baggagePrefix = builder.baggagePrefix;
+    this.b3 = builder.b3;
   }
 
   @Override
@@ -58,6 +71,21 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
     carrier.put(contextKey, encodedValue(spanContext.contextAsString()));
     for (Map.Entry<String, String> entry : spanContext.baggageItems()) {
       carrier.put(keys.prefixedKey(entry.getKey(), baggagePrefix), encodedValue(entry.getValue()));
+    }
+    if (b3) {
+      injectB3(spanContext, carrier);
+    }
+  }
+
+  protected void injectB3(SpanContext spanContext, TextMap carrier) {
+    carrier.put(TRACE_ID_NAME, HexCodec.toLowerHex(spanContext.getTraceId()));
+    if (spanContext.getParentId() != 0L) { // Conventionally, parent id == 0 means the root span
+      carrier.put(PARENT_SPAN_ID_NAME, HexCodec.toLowerHex(spanContext.getParentId()));
+    }
+    carrier.put(SPAN_ID_NAME, HexCodec.toLowerHex(spanContext.getSpanId()));
+    carrier.put(SAMPLED_NAME, spanContext.isSampled() ? "1" : "0");
+    if (spanContext.isDebug()) {
+      carrier.put(FLAGS_NAME, "1");
     }
   }
 
@@ -80,6 +108,9 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
         baggage.put(keys.unprefixedKey(key, baggagePrefix), decodedValue(entry.getValue()));
       }
     }
+    if (context == null && b3) {
+      context = extractB3(carrier);
+    }
     if (context == null) {
       if (debugId != null) {
         return SpanContext.withDebugId(debugId);
@@ -90,6 +121,36 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
       return context;
     }
     return context.withBaggage(baggage);
+  }
+
+  protected SpanContext extractB3(TextMap carrier) {
+    Long traceId = null;
+    Long spanId = null;
+    long parentId = 0L; // Conventionally, parent id == 0 means the root span
+    byte flags = 0;
+    for (Map.Entry<String, String> entry : carrier) {
+      if (entry.getKey().equalsIgnoreCase(SAMPLED_NAME)) {
+        String value = entry.getValue();
+        if ("1".equals(value) || "true".equalsIgnoreCase(value)) {
+          flags |= SAMPLED_FLAG;
+        }
+      } else if (entry.getKey().equalsIgnoreCase(TRACE_ID_NAME)) {
+        traceId = HexCodec.lowerHexToUnsignedLong(entry.getValue());
+      } else if (entry.getKey().equalsIgnoreCase(PARENT_SPAN_ID_NAME)) {
+        parentId = HexCodec.lowerHexToUnsignedLong(entry.getValue());
+      } else if (entry.getKey().equalsIgnoreCase(SPAN_ID_NAME)) {
+        spanId = HexCodec.lowerHexToUnsignedLong(entry.getValue());
+      } else if (entry.getKey().equalsIgnoreCase(FLAGS_NAME)) {
+        if (entry.getValue().equals("1")) {
+          flags |= DEBUG_FLAG;
+        }
+      }
+    }
+
+    if (traceId != null && spanId != null) {
+      return new SpanContext(traceId, spanId, parentId, flags);
+    }
+    return null;
   }
 
   @Override
@@ -105,6 +166,9 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
         .append(',')
         .append("urlEncoding=")
         .append(urlEncoding)
+        .append(',')
+        .append("b3=")
+        .append(b3)
         .append('}');
     return buffer.toString();
   }
@@ -147,6 +211,7 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
     private boolean urlEncoding;
     private String spanContextKey = SPAN_CONTEXT_KEY;
     private String baggagePrefix = BAGGAGE_KEY_PREFIX;
+    private boolean b3 = false;
 
     public Builder withUrlEncoding(boolean urlEncoding) {
       this.urlEncoding = urlEncoding;
@@ -160,6 +225,11 @@ public class TextMapCodec implements Injector<TextMap>, Extractor<TextMap> {
 
     public Builder withBaggagePrefix(String baggagePrefix) {
       this.baggagePrefix = baggagePrefix;
+      return this;
+    }
+
+    public Builder withB3(boolean b3) {
+      this.b3 = b3;
       return this;
     }
 

--- a/jaeger-core/src/test/java/com/uber/jaeger/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/ConfigurationTest.java
@@ -329,6 +329,20 @@ public class ConfigurationTest {
     assertNull(textMap.get("X-B3-SpanId"));
   }
 
+  @Test
+  public void testPropagationValidFormat() {
+    System.setProperty(Configuration.JAEGER_PROPAGATION, "jaeger, invalid");
+    System.setProperty(Configuration.JAEGER_SERVICE_NAME, "Test");
+
+    TestTextMap textMap = new TestTextMap();
+    SpanContext spanContext = new SpanContext(1234, 5678, 0, (byte)0);
+
+    Configuration.fromEnv().getTracer().inject(spanContext, Format.Builtin.TEXT_MAP, textMap);
+
+    // Check that jaeger context still available even though invalid format specified
+    assertNotNull(textMap.get("uber-trace-id"));
+  }
+
   static class TestTextMap implements TextMap {
 
     private Map<String,String> values = new HashMap<>();

--- a/jaeger-core/src/test/java/com/uber/jaeger/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/ConfigurationTest.java
@@ -294,7 +294,7 @@ public class ConfigurationTest {
 
   @Test
   public void testPropagationJaegerAndB3() {
-    System.setProperty(Configuration.JAEGER_PROPAGATION, "jaeger, b3");
+    System.setProperty(Configuration.JAEGER_PROPAGATION, "jaeger,b3");
     System.setProperty(Configuration.JAEGER_SERVICE_NAME, "Test");
 
     long traceId = 1234;
@@ -331,7 +331,7 @@ public class ConfigurationTest {
 
   @Test
   public void testPropagationValidFormat() {
-    System.setProperty(Configuration.JAEGER_PROPAGATION, "jaeger, invalid");
+    System.setProperty(Configuration.JAEGER_PROPAGATION, "jaeger,invalid");
     System.setProperty(Configuration.JAEGER_SERVICE_NAME, "Test");
 
     TestTextMap textMap = new TestTextMap();

--- a/jaeger-core/src/test/java/com/uber/jaeger/propagation/B3TextMapCodecTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/propagation/B3TextMapCodecTest.java
@@ -16,6 +16,7 @@ package com.uber.jaeger.propagation;
 
 import static com.uber.jaeger.propagation.B3TextMapCodec.DEBUG_FLAG;
 import static com.uber.jaeger.propagation.B3TextMapCodec.FLAGS_NAME;
+import static com.uber.jaeger.propagation.B3TextMapCodec.PARENT_SPAN_ID_NAME;
 import static com.uber.jaeger.propagation.B3TextMapCodec.SAMPLED_FLAG;
 import static com.uber.jaeger.propagation.B3TextMapCodec.SAMPLED_NAME;
 import static com.uber.jaeger.propagation.B3TextMapCodec.SPAN_ID_NAME;
@@ -52,6 +53,7 @@ public class B3TextMapCodecTest {
     DelegatingTextMap textMap = new DelegatingTextMap();
     textMap.put(TRACE_ID_NAME, hex128Bits);
     textMap.put(SPAN_ID_NAME, lower64Bits);
+    textMap.put(PARENT_SPAN_ID_NAME, "0");
     textMap.put(SAMPLED_NAME, "1");
     textMap.put(FLAGS_NAME, "1");
 
@@ -59,6 +61,7 @@ public class B3TextMapCodecTest {
 
     assertEquals(HexCodec.lowerHexToUnsignedLong(lower64Bits), context.getTraceId());
     assertEquals(HexCodec.lowerHexToUnsignedLong(lower64Bits), context.getSpanId());
+    assertEquals(0, context.getParentId());
     assertEquals(SAMPLED_FLAG | DEBUG_FLAG, context.getFlags());
   }
 

--- a/jaeger-core/src/test/java/com/uber/jaeger/propagation/B3TextMapCodecTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/propagation/B3TextMapCodecTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2016, Uber Technologies, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.uber.jaeger.propagation;
+
+import static com.uber.jaeger.propagation.B3TextMapCodec.SPAN_ID_NAME;
+import static com.uber.jaeger.propagation.B3TextMapCodec.TRACE_ID_NAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.uber.jaeger.SpanContext;
+import com.uber.jaeger.propagation.HexCodec;
+
+import io.opentracing.propagation.TextMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * NOTE:
+ * These tests are based on the ones from jaeger-b3, and included to improve the test
+ * coverage. The main testing of the B3TextMapCodec is still performed via the tests
+ * in the jaeger-b3 module.
+ *
+ */
+public class B3TextMapCodecTest {
+  static final byte SAMPLED = 1;
+
+  B3TextMapCodec b3Codec = new B3TextMapCodec();
+
+  @Test
+  public void testExtract() throws Exception {
+    String hex128Bits = "463ac35c9f6413ad48485a3953bb6124";
+    String lower64Bits = "48485a3953bb6124";
+
+    DelegatingTextMap textMap = new DelegatingTextMap();
+    textMap.put(TRACE_ID_NAME, hex128Bits);
+    textMap.put(SPAN_ID_NAME, lower64Bits);
+
+    SpanContext context = b3Codec.extract(textMap);
+
+    assertEquals(HexCodec.lowerHexToUnsignedLong(lower64Bits), context.getTraceId());
+    assertEquals(HexCodec.lowerHexToUnsignedLong(lower64Bits), context.getSpanId());
+  }
+
+  @Test
+  public void testInject() throws Exception {
+    DelegatingTextMap textMap = new DelegatingTextMap();
+    b3Codec.inject(new SpanContext(1, 1, 1, SAMPLED), textMap);
+
+    assertTrue(textMap.containsKey(TRACE_ID_NAME));
+    assertTrue(textMap.containsKey(SPAN_ID_NAME));
+  }
+
+  static class DelegatingTextMap implements TextMap {
+    final Map<String, String> delegate = new LinkedHashMap<>();
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator() {
+      return delegate.entrySet().iterator();
+    }
+
+    @Override
+    public void put(String key, String value) {
+      delegate.put(key, value);
+    }
+
+    public boolean containsKey(String key) {
+      return delegate.containsKey(key);
+    }
+  }
+}

--- a/jaeger-core/src/test/java/com/uber/jaeger/propagation/CompositeCodecTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/propagation/CompositeCodecTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2017, The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.uber.jaeger.propagation;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.uber.jaeger.SpanContext;
+
+import io.opentracing.propagation.TextMap;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CompositeCodecTest {
+
+  @Mock
+  private SpanContext mockContext;
+
+  @Mock
+  private TextMap mockCarrier;
+
+  @Mock
+  private Codec<TextMap> mockCodec1;
+
+  @Mock
+  private Codec<TextMap> mockCodec2;
+
+  @Test
+  public void testInject() {
+    CompositeCodec<TextMap> composite = new CompositeCodec<TextMap>(Arrays.asList(mockCodec1, mockCodec2));
+    composite.inject(mockContext, mockCarrier);
+    verify(mockCodec1, times(1)).inject(mockContext, mockCarrier);
+    verify(mockCodec2, times(1)).inject(mockContext, mockCarrier);
+  }
+
+  @Test
+  public void testExtractFromFirstCodec() {
+    when(mockCodec1.extract(mockCarrier)).thenReturn(mockContext);
+    CompositeCodec<TextMap> composite = new CompositeCodec<TextMap>(Arrays.asList(mockCodec1, mockCodec2));
+    assertEquals(mockContext, composite.extract(mockCarrier));
+    verify(mockCodec1, times(1)).extract(mockCarrier);
+    verify(mockCodec2, times(0)).extract(mockCarrier);
+  }
+
+  @Test
+  public void testExtractFromSecondCodec() {
+    when(mockCodec2.extract(mockCarrier)).thenReturn(mockContext);
+    CompositeCodec<TextMap> composite = new CompositeCodec<TextMap>(Arrays.asList(mockCodec1, mockCodec2));
+    assertEquals(mockContext, composite.extract(mockCarrier));
+    verify(mockCodec1, times(1)).extract(mockCarrier);
+    verify(mockCodec2, times(1)).extract(mockCarrier);
+  }
+
+}

--- a/jaeger-core/src/test/java/com/uber/jaeger/propagation/CompositeCodecTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/propagation/CompositeCodecTest.java
@@ -15,7 +15,7 @@
 package com.uber.jaeger.propagation;
 
 import static org.junit.Assert.assertEquals;
-
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -70,6 +70,22 @@ public class CompositeCodecTest {
     assertEquals(mockContext, composite.extract(mockCarrier));
     verify(mockCodec1, times(1)).extract(mockCarrier);
     verify(mockCodec2, times(1)).extract(mockCarrier);
+  }
+
+  @Test
+  public void testExtractFromNoCodec() {
+    CompositeCodec<TextMap> composite = new CompositeCodec<TextMap>(Arrays.asList(mockCodec1, mockCodec2));
+    assertNull(composite.extract(mockCarrier));
+    verify(mockCodec1, times(1)).extract(mockCarrier);
+    verify(mockCodec2, times(1)).extract(mockCarrier);
+  }
+
+  @Test
+  public void testToString() {
+    when(mockCodec1.toString()).thenReturn("codec1");
+    when(mockCodec2.toString()).thenReturn("codec2");
+    CompositeCodec<TextMap> composite = new CompositeCodec<TextMap>(Arrays.asList(mockCodec1, mockCodec2));
+    assertEquals("codec1 : codec2", composite.toString());
   }
 
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/propagation/TextMapCodecTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/propagation/TextMapCodecTest.java
@@ -27,12 +27,14 @@ public class TextMapCodecTest {
         .withUrlEncoding(true)
         .withSpanContextKey("jaeger-trace-id")
         .withBaggagePrefix("jaeger-baggage-")
+        .withB3(true)
         .build();
     assertNotNull(codec);
     String str = codec.toString();
     assertTrue(str.contains("contextKey=jaeger-trace-id"));
     assertTrue(str.contains("baggagePrefix=jaeger-baggage-"));
     assertTrue(str.contains("urlEncoding=true"));
+    assertTrue(str.contains("b3=true"));
   }
 
   @Test
@@ -42,6 +44,7 @@ public class TextMapCodecTest {
     assertTrue(str.contains("contextKey=uber-trace-id"));
     assertTrue(str.contains("baggagePrefix=uberctx-"));
     assertTrue(str.contains("urlEncoding=false"));
+    assertTrue(str.contains("b3=false"));
   }
 
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/propagation/TextMapCodecTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/propagation/TextMapCodecTest.java
@@ -14,10 +14,19 @@
 
 package com.uber.jaeger.propagation;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import org.junit.Test;
+
+import com.uber.jaeger.SpanContext;
+
+import io.opentracing.propagation.TextMap;
 
 public class TextMapCodecTest {
 
@@ -27,14 +36,12 @@ public class TextMapCodecTest {
         .withUrlEncoding(true)
         .withSpanContextKey("jaeger-trace-id")
         .withBaggagePrefix("jaeger-baggage-")
-        .withB3(true)
         .build();
     assertNotNull(codec);
     String str = codec.toString();
     assertTrue(str.contains("contextKey=jaeger-trace-id"));
     assertTrue(str.contains("baggagePrefix=jaeger-baggage-"));
     assertTrue(str.contains("urlEncoding=true"));
-    assertTrue(str.contains("b3=true"));
   }
 
   @Test
@@ -44,7 +51,93 @@ public class TextMapCodecTest {
     assertTrue(str.contains("contextKey=uber-trace-id"));
     assertTrue(str.contains("baggagePrefix=uberctx-"));
     assertTrue(str.contains("urlEncoding=false"));
-    assertTrue(str.contains("b3=false"));
   }
 
+  @Test
+  public void testBuilderWithAnotherCodecInject()  {
+    TextMapCodec codec = TextMapCodec.builder()
+        .withSpanContextKey("jaeger-trace-id")
+        .withCodec(new TestCodec())
+        .build();
+    assertNotNull(codec);
+
+    SpanContext injectedContext = new SpanContext(1, 2, 3, (byte)0);
+    DelegatingTextMap injectedTextMap = new DelegatingTextMap();
+    codec.inject(injectedContext, injectedTextMap);
+
+    // Verify that span context has been recorded in jaeger and the test headers
+    assertEquals(injectedContext.contextAsString(), injectedTextMap.get(TestCodec.KEY));
+    assertEquals(injectedContext.contextAsString(), injectedTextMap.get("jaeger-trace-id"));
+  }
+
+  @Test
+  public void testBuilderWithAnotherCodecExtract()  {
+    TextMapCodec codec = TextMapCodec.builder()
+        .withCodec(new TestCodec())
+        .build();
+    assertNotNull(codec);
+
+    SpanContext originalContext = new SpanContext(1, 2, 3, (byte)0);
+    DelegatingTextMap extractedTextMap = new DelegatingTextMap();
+    extractedTextMap.put(TestCodec.KEY, originalContext.contextAsString());
+    SpanContext extractedContext = codec.extract(extractedTextMap);
+
+    assertEquals(originalContext.contextAsString(), extractedContext.contextAsString());
+  }
+
+  @Test
+  public void testBuilderWithAnotherCodecExtractJaegerTakePriority()  {
+    TextMapCodec codec = TextMapCodec.builder()
+        .withSpanContextKey("jaeger-trace-id")
+        .withCodec(new TestCodec())
+        .build();
+    assertNotNull(codec);
+
+    SpanContext testCodecContext = new SpanContext(1, 2, 3, (byte)0);
+    SpanContext jaegerCodecContext = new SpanContext(4, 5, 6, (byte)0);
+    DelegatingTextMap extractedTextMap = new DelegatingTextMap();
+    extractedTextMap.put(TestCodec.KEY, testCodecContext.contextAsString());
+    extractedTextMap.put("jaeger-trace-id", jaegerCodecContext.contextAsString());
+    SpanContext extractedContext = codec.extract(extractedTextMap);
+
+    assertEquals(jaegerCodecContext.contextAsString(), extractedContext.contextAsString());
+  }
+
+  static class TestCodec implements Codec<TextMap> {
+    final static String KEY = "TestKey";
+
+    @Override
+    public void inject(SpanContext spanContext, TextMap carrier) {
+      carrier.put(KEY, spanContext.contextAsString());
+    }
+
+    @Override
+    public SpanContext extract(TextMap carrier) {
+      if (carrier instanceof DelegatingTextMap) {
+        String value = ((DelegatingTextMap)carrier).get(KEY);
+        if (value != null) {
+          return SpanContext.contextFromString(value);
+        }
+      }
+      return null;
+    }
+  }
+
+  static class DelegatingTextMap implements TextMap {
+    final Map<String, String> delegate = new LinkedHashMap<>();
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator() {
+      return delegate.entrySet().iterator();
+    }
+
+    @Override
+    public void put(String key, String value) {
+      delegate.put(key, value);
+    }
+
+    public String get(String key) {
+      return delegate.get(key);
+    }
+  }
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/propagation/TextMapCodecTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/propagation/TextMapCodecTest.java
@@ -18,15 +18,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.uber.jaeger.SpanContext;
+
+import io.opentracing.propagation.TextMap;
+
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.junit.Test;
-
-import com.uber.jaeger.SpanContext;
-
-import io.opentracing.propagation.TextMap;
 
 public class TextMapCodecTest {
 
@@ -104,7 +104,7 @@ public class TextMapCodecTest {
   }
 
   static class TestCodec implements Codec<TextMap> {
-    final static String KEY = "TestKey";
+    static final String KEY = "TestKey";
 
     @Override
     public void inject(SpanContext spanContext, TextMap carrier) {

--- a/jaeger-core/src/test/java/com/uber/jaeger/propagation/TextMapCodecTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/propagation/TextMapCodecTest.java
@@ -14,17 +14,8 @@
 
 package com.uber.jaeger.propagation;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
-import com.uber.jaeger.SpanContext;
-
-import io.opentracing.propagation.TextMap;
-
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 import org.junit.Test;
 
@@ -53,91 +44,4 @@ public class TextMapCodecTest {
     assertTrue(str.contains("urlEncoding=false"));
   }
 
-  @Test
-  public void testBuilderWithAnotherCodecInject()  {
-    TextMapCodec codec = TextMapCodec.builder()
-        .withSpanContextKey("jaeger-trace-id")
-        .withCodec(new TestCodec())
-        .build();
-    assertNotNull(codec);
-
-    SpanContext injectedContext = new SpanContext(1, 2, 3, (byte)0);
-    DelegatingTextMap injectedTextMap = new DelegatingTextMap();
-    codec.inject(injectedContext, injectedTextMap);
-
-    // Verify that span context has been recorded in jaeger and the test headers
-    assertEquals(injectedContext.contextAsString(), injectedTextMap.get(TestCodec.KEY));
-    assertEquals(injectedContext.contextAsString(), injectedTextMap.get("jaeger-trace-id"));
-  }
-
-  @Test
-  public void testBuilderWithAnotherCodecExtract()  {
-    TextMapCodec codec = TextMapCodec.builder()
-        .withCodec(new TestCodec())
-        .build();
-    assertNotNull(codec);
-
-    SpanContext originalContext = new SpanContext(1, 2, 3, (byte)0);
-    DelegatingTextMap extractedTextMap = new DelegatingTextMap();
-    extractedTextMap.put(TestCodec.KEY, originalContext.contextAsString());
-    SpanContext extractedContext = codec.extract(extractedTextMap);
-
-    assertEquals(originalContext.contextAsString(), extractedContext.contextAsString());
-  }
-
-  @Test
-  public void testBuilderWithAnotherCodecExtractJaegerTakePriority()  {
-    TextMapCodec codec = TextMapCodec.builder()
-        .withSpanContextKey("jaeger-trace-id")
-        .withCodec(new TestCodec())
-        .build();
-    assertNotNull(codec);
-
-    SpanContext testCodecContext = new SpanContext(1, 2, 3, (byte)0);
-    SpanContext jaegerCodecContext = new SpanContext(4, 5, 6, (byte)0);
-    DelegatingTextMap extractedTextMap = new DelegatingTextMap();
-    extractedTextMap.put(TestCodec.KEY, testCodecContext.contextAsString());
-    extractedTextMap.put("jaeger-trace-id", jaegerCodecContext.contextAsString());
-    SpanContext extractedContext = codec.extract(extractedTextMap);
-
-    assertEquals(jaegerCodecContext.contextAsString(), extractedContext.contextAsString());
-  }
-
-  static class TestCodec implements Codec<TextMap> {
-    static final String KEY = "TestKey";
-
-    @Override
-    public void inject(SpanContext spanContext, TextMap carrier) {
-      carrier.put(KEY, spanContext.contextAsString());
-    }
-
-    @Override
-    public SpanContext extract(TextMap carrier) {
-      if (carrier instanceof DelegatingTextMap) {
-        String value = ((DelegatingTextMap)carrier).get(KEY);
-        if (value != null) {
-          return SpanContext.contextFromString(value);
-        }
-      }
-      return null;
-    }
-  }
-
-  static class DelegatingTextMap implements TextMap {
-    final Map<String, String> delegate = new LinkedHashMap<>();
-
-    @Override
-    public Iterator<Map.Entry<String, String>> iterator() {
-      return delegate.entrySet().iterator();
-    }
-
-    @Override
-    public void put(String key, String value) {
-      delegate.put(key, value);
-    }
-
-    public String get(String key) {
-      return delegate.get(key);
-    }
-  }
 }


### PR DESCRIPTION
…ition to Jaeger default context format

Fixes #294 

Have moved the inject/extract code from jaeger-b3 to core in the `TextMapCodec` - but is only enabled based on configuration. jaeger-b3 remains backward compatible, but is also used to test the codec, as it has the dependency on brave.

Signed-off-by: Gary Brown <gary@brownuk.com>