### PR TITLE
[jaeger-client-java] Reduce eagerness of Configuration.getTracer to register a global tracer

### DIFF
--- a/jaeger-context/src/test/java/com/uber/jaeger/context/TracingUtilsTest.java
+++ b/jaeger-context/src/test/java/com/uber/jaeger/context/TracingUtilsTest.java
@@ -17,6 +17,7 @@ package com.uber.jaeger.context;
 import com.uber.jaeger.Configuration;
 import com.uber.jaeger.utils.TestUtils;
 import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
 import java.util.concurrent.Executors;
 import org.junit.After;
 import org.junit.Assert;
@@ -37,6 +38,7 @@ public class TracingUtilsTest {
   @Test
   public void getTraceContext() {
     Tracer tracer = new Configuration("boop").getTracer();
+    GlobalTracer.register(tracer);
     Assert.assertNotNull(tracer);
     Assert.assertNotNull(TracingUtils.getTraceContext());
   }
@@ -49,6 +51,7 @@ public class TracingUtilsTest {
   @Test()
   public void tracedExecutor() throws Exception {
     Tracer tracer = new Configuration("boop").getTracer();
+    GlobalTracer.register(tracer);
     Assert.assertNotNull(tracer);
     Assert.assertNotNull(TracingUtils.tracedExecutor(Executors.newSingleThreadExecutor()));
   }

--- a/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
@@ -126,7 +126,7 @@ public class Configuration {
   public static final String JAEGER_TAGS = JAEGER_PREFIX + "TAGS";
 
   /**
-   * Disables registration with {@link GlobalTracer}.
+   * Enables registration with {@link GlobalTracer}.
    */
   public static final String JAEGER_ENABLE_GLOBAL_TRACER = JAEGER_PREFIX + "ENABLE_GLOBAL_TRACER";
 
@@ -145,8 +145,7 @@ public class Configuration {
   private StatsFactory statsFactory;
 
   /**
-   * Don't use {@link GlobalTracer} to store the tracer.
-   * Use the local {@link #tracer} instead.
+   * Use {@link GlobalTracer} to store the tracer.
    */
   private final boolean enableGlobalTracer;
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
@@ -128,7 +128,7 @@ public class Configuration {
   /**
    * Disables registration with {@link GlobalTracer}.
    */
-  public static final String JAEGER_DISABLE_GLOBAL_TRACER = JAEGER_PREFIX + "DISABLE_GLOBAL_TRACER";
+  public static final String JAEGER_ENABLE_GLOBAL_TRACER = JAEGER_PREFIX + "ENABLE_GLOBAL_TRACER";
 
   /**
    * The serviceName that the tracer will use
@@ -148,7 +148,7 @@ public class Configuration {
    * Don't use {@link GlobalTracer} to store the tracer.
    * Use the local {@link #tracer} instead.
    */
-  private final boolean disableGlobalTracer;
+  private final boolean enableGlobalTracer;
 
   /**
    * lazy singleton Tracer initialized in getTracer() method.
@@ -170,7 +170,7 @@ public class Configuration {
       String serviceName,
       SamplerConfiguration samplerConfig,
       ReporterConfiguration reporterConfig,
-      boolean disableGlobalTracer) {
+      boolean enableGlobalTracer) {
     if (serviceName == null || serviceName.isEmpty()) {
       throw new IllegalArgumentException("Must provide a service name for Jaeger Configuration");
     }
@@ -189,7 +189,7 @@ public class Configuration {
 
     statsFactory = new StatsFactoryImpl(new NullStatsReporter());
 
-    this.disableGlobalTracer = disableGlobalTracer;
+    this.enableGlobalTracer = enableGlobalTracer;
   }
 
   public static Configuration fromEnv() {
@@ -197,7 +197,7 @@ public class Configuration {
         getProperty(JAEGER_SERVICE_NAME),
         SamplerConfiguration.fromEnv(),
         ReporterConfiguration.fromEnv(),
-        getPropertyAsBool(JAEGER_DISABLE_GLOBAL_TRACER));
+        getPropertyAsBool(JAEGER_ENABLE_GLOBAL_TRACER));
   }
 
   public Tracer.Builder getTracerBuilder() {
@@ -215,7 +215,7 @@ public class Configuration {
     tracer = getTracerBuilder().build();
     log.info("Initialized tracer={}", tracer);
 
-    if (!disableGlobalTracer) {
+    if (enableGlobalTracer) {
       GlobalTracer.register(tracer);
     }
 

--- a/jaeger-core/src/test/java/com/uber/jaeger/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/ConfigurationTest.java
@@ -53,7 +53,7 @@ public class ConfigurationTest {
     System.clearProperty(Configuration.JAEGER_SAMPLER_MANAGER_HOST_PORT);
     System.clearProperty(Configuration.JAEGER_SERVICE_NAME);
     System.clearProperty(Configuration.JAEGER_TAGS);
-    System.clearProperty(Configuration.JAEGER_DISABLE_GLOBAL_TRACER);
+    System.clearProperty(Configuration.JAEGER_ENABLE_GLOBAL_TRACER);
     System.clearProperty(Configuration.JAEGER_ENDPOINT);
     System.clearProperty(Configuration.JAEGER_AUTH_TOKEN);
     System.clearProperty(Configuration.JAEGER_USER);
@@ -71,12 +71,13 @@ public class ConfigurationTest {
   public void testFromEnv() {
     System.setProperty(Configuration.JAEGER_SERVICE_NAME, "Test");
     assertNotNull(Configuration.fromEnv().getTracer());
-    assertTrue(GlobalTracer.isRegistered());
+    assertFalse(GlobalTracer.isRegistered());
   }
 
   @Test (expected = IllegalStateException.class)
-  public void testFromEnvWithoutDisabledTracer() {
+  public void testFromEnvWithEnabledTracer() {
     System.setProperty(Configuration.JAEGER_SERVICE_NAME, "Test");
+    System.setProperty(Configuration.JAEGER_ENABLE_GLOBAL_TRACER, "true");
     assertNotNull(Configuration.fromEnv().getTracer());
     assertTrue(GlobalTracer.isRegistered());
 
@@ -84,18 +85,18 @@ public class ConfigurationTest {
   }
 
   @Test
-  public void testDisableGlobalTracer() {
+  public void testEnableGlobalTracer() {
     System.setProperty(Configuration.JAEGER_SERVICE_NAME, "Test");
-    System.setProperty(Configuration.JAEGER_DISABLE_GLOBAL_TRACER, "true");
+    System.setProperty(Configuration.JAEGER_ENABLE_GLOBAL_TRACER, "true");
     assertNotNull(Configuration.fromEnv().getTracer());
-    assertFalse(GlobalTracer.isRegistered());
+    assertTrue(GlobalTracer.isRegistered());
   }
 
   @Test
   public void testDefaultGlobalTracer() {
     Configuration config = new Configuration("Test");
     assertNotNull(config.getTracer());
-    assertTrue(GlobalTracer.isRegistered());
+    assertFalse(GlobalTracer.isRegistered());
   }
 
   @Test

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/JerseyServer.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/JerseyServer.java
@@ -32,6 +32,7 @@ import com.uber.jaeger.senders.Sender;
 import com.uber.jaeger.senders.UdpSender;
 import com.uber.tchannel.api.TChannel.Builder;
 import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -76,7 +77,10 @@ public class JerseyServer {
 
     resources.forEach(rc::register);
 
-    rc.register(TracingUtils.serverFilter(config.getTracer()))
+    Tracer tracer = config.getTracer();
+    GlobalTracer.register(tracer);
+    
+    rc.register(TracingUtils.serverFilter(tracer))
         .register(LoggingFilter.class)
         .register(ExceptionMapper.class)
         .register(JacksonFeature.class)


### PR DESCRIPTION
With this change, we leave it up to the consumer to be the decider for registering a `GlobalTracer`. As much as I understand the reasoning for why it was put there in the first place, I think it's causing a bunch of confusion. 

There is the flag present if people want the call to `getTracer()` to go ahead and register the current tracer as the `GlobalTracer`. 

What do you all think about this?

Signed-off-by: Debosmit Ray <debo@uber.com>