### PR TITLE
Remove concept of registering a GlobalTracer when getting a new tracer

### DIFF
--- a/jaeger-apachehttpclient/src/test/java/com/uber/jaeger/httpclient/JaegerRequestAndResponseInterceptorIntegrationTest.java
+++ b/jaeger-apachehttpclient/src/test/java/com/uber/jaeger/httpclient/JaegerRequestAndResponseInterceptorIntegrationTest.java
@@ -22,8 +22,8 @@ import com.uber.jaeger.context.TracingUtils;
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.samplers.ConstSampler;
 import com.uber.jaeger.samplers.Sampler;
-import com.uber.jaeger.utils.TestUtils;
-import io.opentracing.util.GlobalTracer;
+import io.opentracing.NoopTracerFactory;
+import java.lang.reflect.Field;
 import java.util.List;
 import org.apache.http.HttpHost;
 import org.apache.http.concurrent.FutureCallback;
@@ -67,7 +67,7 @@ public class JaegerRequestAndResponseInterceptorIntegrationTest {
     reporter = new InMemoryReporter();
     Sampler sampler = new ConstSampler(true);
     tracer = new Tracer.Builder("test_service", reporter, sampler).build();
-    GlobalTracer.register(tracer);
+    TracingUtils.setTracer(tracer);
 
     parentSpan = (Span) tracer.buildSpan("parent_operation").startManual();
     parentSpan.setBaggageItem(BAGGAGE_KEY, BAGGAGE_VALUE);
@@ -78,7 +78,9 @@ public class JaegerRequestAndResponseInterceptorIntegrationTest {
 
   @After
   public void tearDown() throws Exception {
-    TestUtils.resetGlobalTracer();
+    Field field = TracingUtils.class.getDeclaredField("tracer");
+    field.setAccessible(true);
+    field.set(null, NoopTracerFactory.create());
   }
 
   @Test

--- a/jaeger-apachehttpclient/src/test/java/com/uber/jaeger/httpclient/JaegerRequestAndResponseInterceptorIntegrationTest.java
+++ b/jaeger-apachehttpclient/src/test/java/com/uber/jaeger/httpclient/JaegerRequestAndResponseInterceptorIntegrationTest.java
@@ -22,7 +22,6 @@ import com.uber.jaeger.context.TracingUtils;
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.samplers.ConstSampler;
 import com.uber.jaeger.samplers.Sampler;
-import io.opentracing.NoopTracerFactory;
 import java.lang.reflect.Field;
 import java.util.List;
 import org.apache.http.HttpHost;
@@ -80,7 +79,7 @@ public class JaegerRequestAndResponseInterceptorIntegrationTest {
   public void tearDown() throws Exception {
     Field field = TracingUtils.class.getDeclaredField("tracer");
     field.setAccessible(true);
-    field.set(null, NoopTracerFactory.create());
+    field.set(null, null);
   }
 
   @Test

--- a/jaeger-context/src/main/java/com/uber/jaeger/context/TracingUtils.java
+++ b/jaeger-context/src/main/java/com/uber/jaeger/context/TracingUtils.java
@@ -14,8 +14,6 @@
 
 package com.uber.jaeger.context;
 
-import io.opentracing.NoopTracer;
-import io.opentracing.NoopTracerFactory;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -24,26 +22,26 @@ import java.util.concurrent.ExecutorService;
  */
 @Deprecated
 public class TracingUtils {
-  private static io.opentracing.Tracer tracer = NoopTracerFactory.create();
+  private static io.opentracing.Tracer tracer = null;
   private static TraceContext traceContext;
 
-  public static void setTracer(io.opentracing.Tracer tracer) {
+  public static synchronized void setTracer(io.opentracing.Tracer tracer) {
     TracingUtils.tracer = tracer;
     TracingUtils.traceContext = new ActiveSpanSourceTraceContext(tracer);
   }
 
-  public static TraceContext getTraceContext() {
+  public static synchronized TraceContext getTraceContext() {
     assertTracerRegistered();
     return traceContext;
   }
 
-  public static ExecutorService tracedExecutor(ExecutorService wrappedExecutorService) {
+  public static synchronized ExecutorService tracedExecutor(ExecutorService wrappedExecutorService) {
     assertTracerRegistered();
     return new TracedExecutorService(wrappedExecutorService, traceContext);
   }
 
   private static void assertTracerRegistered() {
-    if (tracer instanceof NoopTracer) {
+    if (tracer == null) {
       throw new IllegalStateException("Please set a tracer using `setTracer(..)` before calling any functions in this class.");
     }
   }

--- a/jaeger-context/src/main/java/com/uber/jaeger/context/TracingUtils.java
+++ b/jaeger-context/src/main/java/com/uber/jaeger/context/TracingUtils.java
@@ -18,8 +18,17 @@ import io.opentracing.util.GlobalTracer;
 
 import java.util.concurrent.ExecutorService;
 
+/**
+ * TracingUtils is going to be deprecated. To use its method please provide a tracer via
+ * {@link com.uber.jaeger.context.TracingUtils#setTracer(io.opentracing.Tracer)}.
+ */
+@Deprecated
 public class TracingUtils {
   private static TraceContext traceContext = new ActiveSpanSourceTraceContext(GlobalTracer.get());
+
+  public static void setTracer(io.opentracing.Tracer tracer) {
+    GlobalTracer.register(tracer);
+  }
 
   public static TraceContext getTraceContext() {
     assertGlobalTracerRegistered();

--- a/jaeger-context/src/main/java/com/uber/jaeger/context/TracingUtils.java
+++ b/jaeger-context/src/main/java/com/uber/jaeger/context/TracingUtils.java
@@ -42,7 +42,8 @@ public class TracingUtils {
 
   private static void assertTracerRegistered() {
     if (tracer == null) {
-      throw new IllegalStateException("Please set a tracer using `setTracer(..)` before calling any functions in this class.");
+      throw new IllegalStateException(
+          "Please set a tracer using `setTracer(..)` before calling any functions in this class.");
     }
   }
 

--- a/jaeger-context/src/test/java/com/uber/jaeger/context/TracingUtilsTest.java
+++ b/jaeger-context/src/test/java/com/uber/jaeger/context/TracingUtilsTest.java
@@ -15,7 +15,6 @@
 package com.uber.jaeger.context;
 
 import com.uber.jaeger.Configuration;
-import io.opentracing.NoopTracerFactory;
 import io.opentracing.Tracer;
 import java.lang.reflect.Field;
 import java.util.concurrent.Executors;
@@ -29,7 +28,7 @@ public class TracingUtilsTest {
   public void tearDown() throws Exception {
     Field field = TracingUtils.class.getDeclaredField("tracer");
     field.setAccessible(true);
-    field.set(null, NoopTracerFactory.create());
+    field.set(null, null);
   }
 
   @Test(expected = IllegalStateException.class)

--- a/jaeger-context/src/test/java/com/uber/jaeger/context/TracingUtilsTest.java
+++ b/jaeger-context/src/test/java/com/uber/jaeger/context/TracingUtilsTest.java
@@ -15,8 +15,9 @@
 package com.uber.jaeger.context;
 
 import com.uber.jaeger.Configuration;
-import com.uber.jaeger.utils.TestUtils;
+import io.opentracing.NoopTracerFactory;
 import io.opentracing.Tracer;
+import java.lang.reflect.Field;
 import java.util.concurrent.Executors;
 import org.junit.After;
 import org.junit.Assert;
@@ -26,11 +27,13 @@ public class TracingUtilsTest {
 
   @After
   public void tearDown() throws Exception {
-    TestUtils.resetGlobalTracer();
+    Field field = TracingUtils.class.getDeclaredField("tracer");
+    field.setAccessible(true);
+    field.set(null, NoopTracerFactory.create());
   }
 
   @Test(expected = IllegalStateException.class)
-  public void getTraceContextWithoutGlobalTracer() throws Exception {
+  public void getTraceContextWithoutRegisteredTracer() throws Exception {
     TracingUtils.getTraceContext();
   }
 
@@ -44,7 +47,7 @@ public class TracingUtilsTest {
   }
 
   @Test(expected = IllegalStateException.class)
-  public void tracedExecutorWithoutGlobalTracer() throws Exception {
+  public void tracedExecutorWithoutRegisteredTracer() throws Exception {
     TracingUtils.tracedExecutor(null);
   }
 

--- a/jaeger-context/src/test/java/com/uber/jaeger/context/TracingUtilsTest.java
+++ b/jaeger-context/src/test/java/com/uber/jaeger/context/TracingUtilsTest.java
@@ -38,6 +38,8 @@ public class TracingUtilsTest {
   public void getTraceContext() {
     Tracer tracer = new Configuration("boop").getTracer();
     Assert.assertNotNull(tracer);
+
+    TracingUtils.setTracer(tracer);
     Assert.assertNotNull(TracingUtils.getTraceContext());
   }
 
@@ -50,6 +52,7 @@ public class TracingUtilsTest {
   public void tracedExecutor() throws Exception {
     Tracer tracer = new Configuration("boop").getTracer();
     Assert.assertNotNull(tracer);
+    TracingUtils.setTracer(tracer);
     Assert.assertNotNull(TracingUtils.tracedExecutor(Executors.newSingleThreadExecutor()));
   }
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/ConfigurationTest.java
@@ -59,7 +59,6 @@ public class ConfigurationTest {
     System.clearProperty(Configuration.JAEGER_SAMPLER_MANAGER_HOST_PORT);
     System.clearProperty(Configuration.JAEGER_SERVICE_NAME);
     System.clearProperty(Configuration.JAEGER_TAGS);
-    System.clearProperty(Configuration.JAEGER_DISABLE_GLOBAL_TRACER);
     System.clearProperty(Configuration.JAEGER_ENDPOINT);
     System.clearProperty(Configuration.JAEGER_AUTH_TOKEN);
     System.clearProperty(Configuration.JAEGER_USER);
@@ -78,31 +77,7 @@ public class ConfigurationTest {
   public void testFromEnv() {
     System.setProperty(Configuration.JAEGER_SERVICE_NAME, "Test");
     assertNotNull(Configuration.fromEnv().getTracer());
-    assertTrue(GlobalTracer.isRegistered());
-  }
-
-  @Test (expected = IllegalStateException.class)
-  public void testFromEnvWithoutDisabledTracer() {
-    System.setProperty(Configuration.JAEGER_SERVICE_NAME, "Test");
-    assertNotNull(Configuration.fromEnv().getTracer());
-    assertTrue(GlobalTracer.isRegistered());
-
-    Configuration.fromEnv().getTracer();
-  }
-
-  @Test
-  public void testDisableGlobalTracer() {
-    System.setProperty(Configuration.JAEGER_SERVICE_NAME, "Test");
-    System.setProperty(Configuration.JAEGER_DISABLE_GLOBAL_TRACER, "true");
-    assertNotNull(Configuration.fromEnv().getTracer());
     assertFalse(GlobalTracer.isRegistered());
-  }
-
-  @Test
-  public void testDefaultGlobalTracer() {
-    Configuration config = new Configuration("Test");
-    assertNotNull(config.getTracer());
-    assertTrue(GlobalTracer.isRegistered());
   }
 
   @Test

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/JerseyServer.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/JerseyServer.java
@@ -76,7 +76,11 @@ public class JerseyServer {
 
     resources.forEach(rc::register);
 
-    rc.register(TracingUtils.serverFilter(config.getTracer()))
+    // register a tracer with TracingUtils before proceeding
+    io.opentracing.Tracer tracer = config.getTracer();
+    TracingUtils.setTracer(tracer);
+
+    rc.register(TracingUtils.serverFilter(tracer))
         .register(LoggingFilter.class)
         .register(ExceptionMapper.class)
         .register(JacksonFeature.class)

--- a/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
+++ b/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
@@ -22,8 +22,8 @@ import com.uber.jaeger.Tracer;
 import com.uber.jaeger.context.TracingUtils;
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.samplers.ConstSampler;
-import com.uber.jaeger.utils.TestUtils;
-import io.opentracing.util.GlobalTracer;
+import io.opentracing.NoopTracerFactory;
+import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -49,7 +49,7 @@ public class JerseyServerFilterTest extends JerseyTest {
 
     ResourceConfig resourceConfig = new ResourceConfig(HelloResource.class,
                                                        StormlordResource.class);
-    GlobalTracer.register(tracer);
+    TracingUtils.setTracer(tracer);
     undertest = new JerseyServerFilter(tracer, TracingUtils.getTraceContext());
     resourceConfig.register(undertest);
     return resourceConfig;
@@ -59,7 +59,11 @@ public class JerseyServerFilterTest extends JerseyTest {
   @After
   public void tearDown() throws Exception {
     super.tearDown();
-    TestUtils.resetGlobalTracer();
+
+    // clean up tracing utils tracer instance
+    Field field = TracingUtils.class.getDeclaredField("tracer");
+    field.setAccessible(true);
+    field.set(null, NoopTracerFactory.create());
   }
 
   @Path("hello")

--- a/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
+++ b/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/JerseyServerFilterTest.java
@@ -22,7 +22,6 @@ import com.uber.jaeger.Tracer;
 import com.uber.jaeger.context.TracingUtils;
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.samplers.ConstSampler;
-import io.opentracing.NoopTracerFactory;
 import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Map;
@@ -63,7 +62,7 @@ public class JerseyServerFilterTest extends JerseyTest {
     // clean up tracing utils tracer instance
     Field field = TracingUtils.class.getDeclaredField("tracer");
     field.setAccessible(true);
-    field.set(null, NoopTracerFactory.create());
+    field.set(null, null);
   }
 
   @Path("hello")

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
@@ -16,9 +16,20 @@ package com.uber.jaeger.filters.jaxrs2;
 
 import com.uber.jaeger.context.TraceContext;
 import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
 import java.util.concurrent.ExecutorService;
 
+/**
+ * TracingUtils is going to be deprecated. To use its method please provide a tracer via
+ * {@link com.uber.jaeger.filters.jaxrs2.TracingUtils#setTracer(io.opentracing.Tracer)}.
+ */
+@Deprecated
 public class TracingUtils {
+
+  public static void setTracer(io.opentracing.Tracer tracer) {
+    GlobalTracer.register(tracer);
+  }
+
   @Deprecated
   public static TraceContext getTraceContext() {
     return com.uber.jaeger.context.TracingUtils.getTraceContext();

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
@@ -25,25 +25,25 @@ import java.util.concurrent.ExecutorService;
 @Deprecated
 public class TracingUtils {
 
-  public static void setTracer(io.opentracing.Tracer tracer) {
+  public static synchronized void setTracer(io.opentracing.Tracer tracer) {
     com.uber.jaeger.context.TracingUtils.setTracer(tracer);
   }
 
   @Deprecated
-  public static TraceContext getTraceContext() {
+  public static synchronized TraceContext getTraceContext() {
     return com.uber.jaeger.context.TracingUtils.getTraceContext();
   }
 
   @Deprecated
-  public static ExecutorService tracedExecutor(ExecutorService wrappedExecutorService) {
+  public static synchronized ExecutorService tracedExecutor(ExecutorService wrappedExecutorService) {
     return com.uber.jaeger.context.TracingUtils.tracedExecutor(wrappedExecutorService);
   }
 
-  public static ClientFilter clientFilter(Tracer tracer) {
+  public static synchronized ClientFilter clientFilter(Tracer tracer) {
     return new ClientFilter(tracer, getTraceContext());
   }
 
-  public static ServerFilter serverFilter(Tracer tracer) {
+  public static synchronized ServerFilter serverFilter(Tracer tracer) {
     return new ServerFilter(tracer, getTraceContext());
   }
 

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
@@ -16,7 +16,6 @@ package com.uber.jaeger.filters.jaxrs2;
 
 import com.uber.jaeger.context.TraceContext;
 import io.opentracing.Tracer;
-import io.opentracing.util.GlobalTracer;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -27,7 +26,7 @@ import java.util.concurrent.ExecutorService;
 public class TracingUtils {
 
   public static void setTracer(io.opentracing.Tracer tracer) {
-    GlobalTracer.register(tracer);
+    com.uber.jaeger.context.TracingUtils.setTracer(tracer);
   }
 
   @Deprecated

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
@@ -25,25 +25,25 @@ import java.util.concurrent.ExecutorService;
 @Deprecated
 public class TracingUtils {
 
-  public static synchronized void setTracer(io.opentracing.Tracer tracer) {
+  public static void setTracer(io.opentracing.Tracer tracer) {
     com.uber.jaeger.context.TracingUtils.setTracer(tracer);
   }
 
   @Deprecated
-  public static synchronized TraceContext getTraceContext() {
+  public static TraceContext getTraceContext() {
     return com.uber.jaeger.context.TracingUtils.getTraceContext();
   }
 
   @Deprecated
-  public static synchronized ExecutorService tracedExecutor(ExecutorService wrappedExecutorService) {
+  public static ExecutorService tracedExecutor(ExecutorService wrappedExecutorService) {
     return com.uber.jaeger.context.TracingUtils.tracedExecutor(wrappedExecutorService);
   }
 
-  public static synchronized ClientFilter clientFilter(Tracer tracer) {
+  public static ClientFilter clientFilter(Tracer tracer) {
     return new ClientFilter(tracer, getTraceContext());
   }
 
-  public static synchronized ServerFilter serverFilter(Tracer tracer) {
+  public static ServerFilter serverFilter(Tracer tracer) {
     return new ServerFilter(tracer, getTraceContext());
   }
 


### PR DESCRIPTION
TracingUtils classes have been deprecated. There is a new method called `setTracer(io.opentracing.Tracer)` that can be used to continue using the methods in that class. 

When trying to get a tracer from `jaeger.core.Configuration` object, it was previously registering that tracer as a global tracer. That functionality and the related environment variables have been removed. 

Users will have to be responsible a local tracer as a Global Tracer.

Signed-off-by: Debosmit Ray <debo@uber.com>