### PR TITLE
Make apache context span key public

### DIFF
--- a/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/Constants.java
+++ b/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/Constants.java
@@ -14,8 +14,6 @@
 
 package com.uber.jaeger.httpclient;
 
-public class Constants {
-  static final String CURRENT_SPAN_CONTEXT_KEY = "io.opentracing.Span";
-
-  private Constants() {}
+public interface Constants {
+  String CURRENT_SPAN_CONTEXT_KEY = "io.opentracing.Span";
 }

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/Constants.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/Constants.java
@@ -14,6 +14,6 @@
 
 package com.uber.jaeger.filters.jaxrs2;
 
-public class Constants {
-  public static final String CURRENT_SPAN_CONTEXT_KEY = "io.opentracing.Span";
+public interface Constants {
+  String CURRENT_SPAN_CONTEXT_KEY = "io.opentracing.Span";
 }


### PR DESCRIPTION
- apache http context key for span was not public
- using interfaces to store public constants to allow for easier static imports for both apache and jaxrs2

Signed-off-by: Debosmit Ray <debo@uber.com>