### PR TITLE
Proof-of-concept: Jaeger configuration returns Jaeger Tracer

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
@@ -155,9 +155,9 @@ public class Configuration {
   }
 
   /**
-   * The serviceName that the tracer will use
+   * The serviceName that the tracer will use.
    */
-  private final String serviceName;
+  protected final String serviceName;
 
   private final SamplerConfiguration samplerConfig;
 
@@ -168,12 +168,12 @@ public class Configuration {
   /**
    * A interface that wraps an underlying metrics generator in order to report Jaeger's metrics.
    */
-  private StatsFactory statsFactory;
+  protected StatsFactory statsFactory;
 
   /**
    * lazy singleton Tracer initialized in getTracer() method.
    */
-  private Tracer tracer;
+  protected Tracer tracer;
 
   public Configuration(String serviceName) {
     this(serviceName, null, null);
@@ -233,7 +233,7 @@ public class Configuration {
     return builder;
   }
 
-  public synchronized io.opentracing.Tracer getTracer() {
+  public synchronized com.uber.jaeger.Tracer getTracer() {
     if (tracer != null) {
       return tracer;
     }
@@ -750,7 +750,7 @@ public class Configuration {
     return Boolean.valueOf(getProperty(name));
   }
 
-  private static Map<String, String> tracerTagsFromEnv() {
+  protected static Map<String, String> tracerTagsFromEnv() {
     Map<String, String> tracerTagMaps = null;
     String tracerTags = getProperty(JAEGER_TAGS);
     if (tracerTags != null) {

--- a/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/ConfigurationTest.java
+++ b/jaeger-dropwizard/src/test/java/com/uber/jaeger/dropwizard/ConfigurationTest.java
@@ -14,6 +14,18 @@
 
 package com.uber.jaeger.dropwizard;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+import com.uber.jaeger.reporters.NoopReporter;
+import com.uber.jaeger.reporters.RemoteReporter;
+import com.uber.jaeger.reporters.Reporter;
+import com.uber.jaeger.samplers.ConstSampler;
+import com.uber.jaeger.samplers.RemoteControlledSampler;
+import com.uber.jaeger.samplers.Sampler;
+import java.lang.reflect.Field;
 import org.junit.Test;
 
 public class ConfigurationTest {
@@ -33,5 +45,52 @@ public class ConfigurationTest {
   public void testCanCloseTracer() throws Exception {
     Configuration configuration = new Configuration("serviceName", false, null, null);
     configuration.closeTracer();
+  }
+
+  @Test
+  public void testGetTracerWhenDisabled() throws Exception {
+    Configuration configuration = new Configuration("serviceName", true, null, null);
+    io.opentracing.Tracer tracer = configuration.getTracer();
+    assertThat(tracer, instanceOf(com.uber.jaeger.Tracer.class));
+
+    Field reporterField = com.uber.jaeger.Tracer.class.getDeclaredField("reporter");
+    reporterField.setAccessible(true);
+    Reporter reporter = (Reporter) reporterField.get(tracer);
+    assertThat(reporter, instanceOf(NoopReporter.class));
+
+    Field samplerField = com.uber.jaeger.Tracer.class.getDeclaredField("sampler");
+    samplerField.setAccessible(true);
+    Sampler sampler = (Sampler) samplerField.get(tracer);
+    assertThat(sampler, instanceOf(ConstSampler.class));
+
+    Field samplerDecisionField = ConstSampler.class.getDeclaredField("decision");
+    samplerDecisionField.setAccessible(true);
+    Boolean decisionValue = (Boolean) samplerDecisionField.get(sampler);
+    assertFalse(decisionValue);
+  }
+
+  @Test
+  public void testMultipleGetTracerCallsReturnsSameInstanceOfTracer() {
+    Configuration configuration = new Configuration("serviceName", true, null, null);
+    io.opentracing.Tracer tracer = configuration.getTracer();
+
+    assertEquals(tracer, configuration.getTracer());
+  }
+
+  @Test
+  public void testGetTracerWhenEnabled() throws Exception {
+    Configuration configuration = new Configuration("serviceName", false, null, null);
+    io.opentracing.Tracer tracer = configuration.getTracer();
+    assertThat(tracer, instanceOf(com.uber.jaeger.Tracer.class));
+
+    Field reporterField = com.uber.jaeger.Tracer.class.getDeclaredField("reporter");
+    reporterField.setAccessible(true);
+    Reporter reporter = (Reporter) reporterField.get(tracer);
+    assertThat(reporter, instanceOf(RemoteReporter.class));
+
+    Field samplerField = com.uber.jaeger.Tracer.class.getDeclaredField("sampler");
+    samplerField.setAccessible(true);
+    Sampler sampler = (Sampler) samplerField.get(tracer);
+    assertThat(sampler, instanceOf(RemoteControlledSampler.class));
   }
 }


### PR DESCRIPTION
Mostly c/p from opentracing.noop to show how something like this would work.

Ideally, just changing return type of `com.uber.jaeger.Configuration#getTracer` would do the trick. But, since `com.uber.jaeger.dropwizard.Configuration` sub-classes `com.uber.jaeger.Configuration` and also supports `disable` state, that returns an `NoopTracer` (which is an `io.opentracing.Tracer`), we can't change that return-type to `com.uber.jaeger.Tracer`.