### PR TITLE
Allow passing debug span baggage from non-jaegerized clients

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,7 @@ subprojects {
     }
 
     dependencies {
+        compile group: 'org.jetbrains', name: 'annotations', version: '15.0'
         compileOnly 'org.projectlombok:lombok:1.16.18'
         compileOnly 'org.codehaus.mojo:animal-sniffer-annotations:1.16'
     }

--- a/jaeger-core/build.gradle
+++ b/jaeger-core/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: gsonVersion
     compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
     compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.9.0'
+    compile group: 'com.google.guava', name: 'guava', version: guavaVersion
 
     // Testing frameworks
     // Jersey dependencies for unit tests
@@ -17,6 +18,7 @@ dependencies {
     testCompile group: 'com.tngtech.java', name: 'junit-dataprovider', version: junitDataProviderVersion
     testCompile group: 'org.awaitility', name: 'awaitility', version: awaitilityVersion
     testCompile group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
+    testCompile group: 'com.google.code.gson', name: 'gson', version: gsonVersion
 
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 }

--- a/jaeger-core/src/main/java/com/uber/jaeger/Constants.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Constants.java
@@ -39,8 +39,15 @@ public class Constants {
    * An external process can inject baggage by setting the special HTTP Header jaeger-baggage
    * on a request. This is expected to be used by external processes to inject span baggage into
    * span context in cases where it is not created by a Jaeger-instrumented client/server.
+   *
+   * Debug jaeger baggage is loaded for a header item that looks like,
+   * <pre>
+   * {@code
+   *    "jaeger-baggage": "k1=v1,k2=v2"
+   * }
+   * </pre>
    */
-  public static final String DEBUG_JAEGER_SPAN_BAGGAGE_HEADER = "jaeger-baggage";
+  public static final String MANUAL_BAGGAGE_HEADER_KEY = "jaeger-baggage";
 
   /**
    * The name of the tag used to report client version.

--- a/jaeger-core/src/main/java/com/uber/jaeger/Constants.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Constants.java
@@ -36,6 +36,13 @@ public class Constants {
   public static final String DEBUG_ID_HEADER_KEY = "jaeger-debug-id";
 
   /**
+   * An external process can inject baggage by setting the special HTTP Header jaeger-baggage
+   * on a request. This is expected to be used by external processes to inject span baggage into
+   * span context in cases where it is not created by a Jaeger-instrumented client/server.
+   */
+  public static final String DEBUG_JAEGER_SPAN_BAGGAGE_HEADER = "jaeger-baggage";
+
+  /**
    * The name of the tag used to report client version.
    */
   public static final String JAEGER_CLIENT_VERSION_TAG_KEY = "jaeger.version";

--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -283,11 +283,11 @@ public class Tracer implements io.opentracing.Tracer, Closeable {
         }
       }
 
-      return new SpanContext(id, id, 0, flags);
+      return new SpanContext(id, id, 0, flags, createChildBaggage(), debugId);
     }
 
     private Map<String, String> createChildBaggage() {
-      Map<String, String> baggage = null;
+      Map<String, String> baggage = new HashMap();
 
       // optimization for 99% use cases, when there is only one parent
       if (references.size() == 1) {
@@ -296,9 +296,6 @@ public class Tracer implements io.opentracing.Tracer, Closeable {
 
       for (Reference reference: references) {
         if (reference.getSpanContext().baggage() != null) {
-          if (baggage == null) {
-            baggage = new HashMap<String, String>();
-          }
           baggage.putAll(reference.getSpanContext().baggage());
         }
       }

--- a/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Tracer.java
@@ -31,14 +31,12 @@ import com.uber.jaeger.samplers.SamplingStatus;
 import com.uber.jaeger.utils.Clock;
 import com.uber.jaeger.utils.SystemClock;
 import com.uber.jaeger.utils.Utils;
-
 import io.opentracing.References;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
 import io.opentracing.util.ThreadLocalScopeManager;
-
 import java.io.Closeable;
 import java.io.InputStream;
 import java.net.Inet4Address;
@@ -287,13 +285,12 @@ public class Tracer implements io.opentracing.Tracer, Closeable {
     }
 
     private Map<String, String> createChildBaggage() {
-      Map<String, String> baggage = new HashMap();
-
       // optimization for 99% use cases, when there is only one parent
       if (references.size() == 1) {
         return references.get(0).getSpanContext().baggage();
       }
 
+      Map<String, String> baggage = new HashMap<String, String>();
       for (Reference reference: references) {
         if (reference.getSpanContext().baggage() != null) {
           baggage.putAll(reference.getSpanContext().baggage());

--- a/jaeger-core/src/test/java/com/uber/jaeger/propagation/TextMapCodecTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/propagation/TextMapCodecTest.java
@@ -44,4 +44,6 @@ public class TextMapCodecTest {
     assertTrue(str.contains("urlEncoding=false"));
   }
 
+  // FIXME: This test class is extremely incomplete and barely unittests TextMapCodec.
+
 }

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/ServerFilterIntegrationTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/ServerFilterIntegrationTest.java
@@ -1,10 +1,29 @@
+/*
+ * Copyright (c) 2018, Uber Technologies, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.uber.jaeger.propagation;
 
 import static com.uber.jaeger.Constants.DEBUG_ID_HEADER_KEY;
-import static com.uber.jaeger.Constants.DEBUG_JAEGER_SPAN_BAGGAGE_HEADER;
+import static com.uber.jaeger.Constants.MANUAL_BAGGAGE_HEADER_KEY;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
-import com.uber.jaeger.context.ActiveSpanSourceTraceContext;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.uber.jaeger.context.ScopeManagerTraceContext;
 import com.uber.jaeger.context.TraceContext;
 import com.uber.jaeger.filters.jaxrs2.ClientFilter;
 import com.uber.jaeger.filters.jaxrs2.ServerFilter;
@@ -12,16 +31,17 @@ import com.uber.jaeger.reporters.NoopReporter;
 import com.uber.jaeger.samplers.ConstSampler;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
-import java.io.IOException;
 import java.net.URI;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Priorities;
+import javax.ws.rs.Produces;
 import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import jersey.repackaged.com.google.common.collect.ImmutableMap;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -33,16 +53,19 @@ import org.junit.Test;
 public class ServerFilterIntegrationTest extends JerseyTest {
 
   // Base URI the Grizzly HTTP server will listen on
-  private static final String BASE_URI = "http://localhost:8080/";
+  private static final String BASE_URI = "http://localhost:0/";
 
   private Tracer clientTracer =
       new com.uber.jaeger.Tracer
           .Builder("client-tracer", new NoopReporter(), new ConstSampler(true))
           .build();
 
-  private TraceContext clientTraceContext = new ActiveSpanSourceTraceContext(clientTracer);
+  private TraceContext clientTraceContext =
+      new ScopeManagerTraceContext(clientTracer.scopeManager());
 
   private HttpServer server;
+
+  private final Gson gson = new Gson();
 
   @Override
   @Before
@@ -61,8 +84,14 @@ public class ServerFilterIntegrationTest extends JerseyTest {
 
     // stop the server
     if (server.isStarted()) {
-      server.stop();
+      server.shutdownNow();
     }
+
+    // clean the client side trace context and close out the tracer
+    while (!clientTraceContext.isEmpty()) {
+      clientTraceContext.pop();
+    }
+    ((com.uber.jaeger.Tracer) clientTracer).close();
   }
 
   @Override
@@ -73,14 +102,11 @@ public class ServerFilterIntegrationTest extends JerseyTest {
             .Builder("server-tracer", new NoopReporter(), new ConstSampler(true))
             .build();
 
-    TraceContext serverTraceContext = new ActiveSpanSourceTraceContext(serverTracer);
-    
     // Our 'Application'
     ResourceConfig resourceConfig =
         new ResourceConfig()
-            .register(new ServerFilter(serverTracer, serverTraceContext), Priorities.USER + 10)
-            .register(new TestHookFilter(serverTraceContext), Priorities.USER + 20)
-            .register(TestResource.class);
+            .register(new ServerFilter(serverTracer), Priorities.USER + 10)
+            .register(new TestResource(serverTracer));
 
     return resourceConfig;
   }
@@ -95,103 +121,201 @@ public class ServerFilterIntegrationTest extends JerseyTest {
 
   @Test
   public void testTracingUsingInstrumentedClient() {
+    /**
+     * Goal:
+     * When trace ID is present
+     *    - baggage from uberctx- is respected
+     *    - baggage from jaeger-baggage is not respected
+     * Debug ID is always respected regardless of other data
+     */
     com.uber.jaeger.Span span = (com.uber.jaeger.Span) clientTracer
         .buildSpan("root-span")
-        .startManual();
-    span.setBaggageItem("x-test", "testing");
+        .start();
+    span.setBaggageItem("x-test", "testing");  // uberctx- baggage
     clientTraceContext.push(span);
 
-    Response resp = target()
-        .register(new ClientFilter(clientTracer, clientTraceContext))
+    Response response = target()
+        .register(new ClientFilter(clientTracer))
         .path("test")
         .request()
-        .header(DEBUG_JAEGER_SPAN_BAGGAGE_HEADER, "foo=bar")
+        .header(MANUAL_BAGGAGE_HEADER_KEY, "foo=bar")  // debug jaeger baggage
         .get();
-    assertEquals(resp.getStatus(), 200);
+    assertEquals(response.getStatus(), 200);
+
+    String responseString = response.readEntity(String.class);
+    JsonElement jsonElement =
+        gson.fromJson(responseString, JsonElement.class);
+    JsonObject jsonResponse = jsonElement.getAsJsonObject();
+
+    // baggage from uberctx- is respected
+    assertEquals("testing", jsonResponse.get("x-test").getAsString());
+
+    // baggage from jaeger-baggage is not respected
+    assertNotEquals("bar", jsonResponse.get("foo").getAsString());
   }
 
   @Test
-  public void testTracingUsingInstrumentedClientWithFakeBaggageHeader() {
-    Response resp = target()
-        .register(new ClientFilter(clientTracer, clientTraceContext))
+  public void testTracingUsingInstrumentedClientWithFakeBaggageHeaderButNoDebugTraceId() {
+    /**
+     * Goal:
+     * When trace ID is present
+     *    - baggage from uberctx- is respected
+     *    - baggage from jaeger-baggage is not respected
+     */
+    Response response = target()
+        .register(new ClientFilter(clientTracer))
         .path("test")
         .request()
-        .header(DEBUG_JAEGER_SPAN_BAGGAGE_HEADER, "foo=bar")
-        .header("uberctx-x-test", "testing")
+        .header(MANUAL_BAGGAGE_HEADER_KEY, "foo=bar")  // debug jaeger baggage
+        .header("uberctx-x-test", "testing")  // uberctx- baggage
         .get();
-    assertEquals(resp.getStatus(), 200);
+    assertEquals(response.getStatus(), 200);
+
+    String responseString = response.readEntity(String.class);
+    JsonElement jsonElement =
+        gson.fromJson(responseString, JsonElement.class);
+    JsonObject jsonResponse = jsonElement.getAsJsonObject();
+
+    assertEquals("testing", jsonResponse.get("x-test").getAsString());
+    assertNotEquals("bar", jsonResponse.get("foo").getAsString());
+  }
+
+  @Test
+  public void testTracingUsingInstrumentedClientWithFakeBaggageHeaderAndDebugTraceId() {
+    /**
+     * Goal:
+     * When both trace ID and debug ID is present
+     *    - baggage from uberctx- is not respected
+     *    - baggage from jaeger-baggage is respected
+     */
+    Response response = target()
+        .register(new ClientFilter(clientTracer))
+        .path("test")
+        .request()
+        .header(DEBUG_ID_HEADER_KEY, "")
+        .header(MANUAL_BAGGAGE_HEADER_KEY, "foo=bar")  // debug jaeger baggage
+        .header("uberctx-x-test", "testing")  // uberctx- baggage
+        .get();
+    assertEquals(response.getStatus(), 200);
+
+    String responseString = response.readEntity(String.class);
+    JsonElement jsonElement =
+        gson.fromJson(responseString, JsonElement.class);
+    JsonObject jsonResponse = jsonElement.getAsJsonObject();
+
+    assertNotEquals("testing", jsonResponse.get("x-test").getAsString());
+    assertEquals("bar", jsonResponse.get("foo").getAsString());
   }
 
   @Test
   public void testTracingUsingNonInstrumentedClient() {
-    Response resp = target()
+    /**
+     * Goal:
+     * When trace ID is not present, and debug ID is present
+     *    - baggage from jaeger-baggage is respected
+     */
+    Response response = target()
         .path("test")
         .request()
         .header(DEBUG_ID_HEADER_KEY, "12345")
-        .header(DEBUG_JAEGER_SPAN_BAGGAGE_HEADER, "foo=bar,x-test=testing")
+        .header(MANUAL_BAGGAGE_HEADER_KEY, "foo=bar,x-test=testing")
         .get();
-    assertEquals(resp.getStatus(), 200);
+    assertEquals(response.getStatus(), 200);
+
+    String responseString = response.readEntity(String.class);
+    JsonElement jsonElement =
+        gson.fromJson(responseString, JsonElement.class);
+    JsonObject jsonResponse = jsonElement.getAsJsonObject();
+    assertEquals(jsonResponse.get("x-test").getAsString(), "testing");
+    assertEquals(jsonResponse.get("foo").getAsString(), "bar");
   }
 
   @Test
   public void testTracingUsingNonInstrumentedClientWithFakeBaggageHeader() {
-    Response resp = target()
+    /**
+     * Goal:
+     * When trace ID is not present, and debug ID is present
+     *    - baggage from uberctx- is not respected
+     *    - baggage from jaeger-baggage is respected
+     */
+    Response response = target()
         .path("test")
         .request()
         .header(DEBUG_ID_HEADER_KEY, "12345")
-        .header(DEBUG_JAEGER_SPAN_BAGGAGE_HEADER, "foo=bar")
+        .header(MANUAL_BAGGAGE_HEADER_KEY, "foo=bar")
         .header("uberctx-x-test", "testing")
         .get();
-    assertEquals(resp.getStatus(), 200);
+    assertEquals(response.getStatus(), 200);
+
+    String responseString = response.readEntity(String.class);
+    JsonElement jsonElement =
+        gson.fromJson(responseString, JsonElement.class);
+    JsonObject jsonResponse = jsonElement.getAsJsonObject();
+    assertNotEquals("testing", jsonResponse.get("x-test").getAsString());
+    assertEquals("bar", jsonResponse.get("foo").getAsString());
   }
 
   @Test
   public void testTracingUsingNonInstrumentedClientAndNoDebugId() {
     /**
-     * this test shows that in case where there is no uber-trace-id (non-instrumented client),
-     * only way to force baggage to get populated is to include the ``"jaeger-debug-id"`` header.
+     * Goal:
+     * When neither trace ID, nor debug ID is present, no baggage population takes place.
      */
-    Response resp = target()
+    Response response = target()
         .path("test")
         .request()
-        .header(DEBUG_JAEGER_SPAN_BAGGAGE_HEADER, "foo=bar")
+        .header(MANUAL_BAGGAGE_HEADER_KEY, "foo=bar")
         .header("uberctx-x-test", "testing")
         .get();
-    assertEquals(resp.getStatus(), 500);
-  }
+    assertEquals(response.getStatus(), 200);
 
-  class TestHookFilter implements ContainerRequestFilter {
-
-    private final TraceContext serverTraceContext;
-
-    public TestHookFilter(TraceContext serverTraceContext) {
-      this.serverTraceContext = serverTraceContext;
-    }
-
-    @Override
-    public void filter(ContainerRequestContext requestContext) throws IOException {
-      Span curSpan = serverTraceContext.getCurrentSpan();
-
-      if (curSpan == null) {
-        requestContext.abortWith(
-            Response.status(Response.Status.UNAUTHORIZED)
-                .entity("Whoops! No span; make sure that the ServerFilter is in place")
-                .build()
-        );
-        return;
-      }
-
-      assertEquals(curSpan.getBaggageItem("x-test"), "testing");
-      assertEquals(curSpan.getBaggageItem("foo"), "bar");
-    }
+    String responseString = response.readEntity(String.class);
+    JsonElement jsonElement =
+        gson.fromJson(responseString, JsonElement.class);
+    JsonObject jsonResponse = jsonElement.getAsJsonObject();
+    assertNotEquals("testing", jsonResponse.get("x-test").getAsString());
+    assertNotEquals("bar", jsonResponse.get("foo").getAsString());
   }
 
   @Path("test")
   public static class TestResource {
 
+    private final Tracer serverTracer;
+
+    public TestResource(Tracer serverTracer) {
+      this.serverTracer = serverTracer;
+    }
+
     @GET
-    public Response test(@Context ContainerRequestContext ctx) {
-      return Response.ok().build();
+    @Produces({"application/json"})
+    public Response test(@Context ContainerRequestContext requestContext) {
+      Span curSpan = serverTracer.activeSpan();
+
+      if (curSpan == null) {
+        String response = new GsonBuilder()
+            .create()
+            .toJson(ImmutableMap
+              .of("error", "Whoops! No span; make sure that the ServerFilter is in place")
+            );
+
+        return Response
+            .status(Status.UNAUTHORIZED)
+            .entity(response)
+            .build();
+      }
+
+      String response = new GsonBuilder()
+          .create()
+          .toJson(ImmutableMap
+              .builder()
+              .put("x-test", String.valueOf(curSpan.getBaggageItem("x-test")))
+              .put("foo", String.valueOf(curSpan.getBaggageItem("foo")))
+              .build());
+
+      return Response
+          .ok()
+          .entity(response)
+          .build();
     }
   }
 }

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/ServerFilterIntegrationTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/ServerFilterIntegrationTest.java
@@ -1,0 +1,197 @@
+package com.uber.jaeger.propagation;
+
+import static com.uber.jaeger.Constants.DEBUG_ID_HEADER_KEY;
+import static com.uber.jaeger.Constants.DEBUG_JAEGER_SPAN_BAGGAGE_HEADER;
+import static org.junit.Assert.assertEquals;
+
+import com.uber.jaeger.context.ActiveSpanSourceTraceContext;
+import com.uber.jaeger.context.TraceContext;
+import com.uber.jaeger.filters.jaxrs2.ClientFilter;
+import com.uber.jaeger.filters.jaxrs2.ServerFilter;
+import com.uber.jaeger.reporters.NoopReporter;
+import com.uber.jaeger.samplers.ConstSampler;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import java.io.IOException;
+import java.net.URI;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ServerFilterIntegrationTest extends JerseyTest {
+
+  // Base URI the Grizzly HTTP server will listen on
+  private static final String BASE_URI = "http://localhost:8080/";
+
+  private Tracer clientTracer =
+      new com.uber.jaeger.Tracer
+          .Builder("client-tracer", new NoopReporter(), new ConstSampler(true))
+          .build();
+
+  private TraceContext clientTraceContext = new ActiveSpanSourceTraceContext(clientTracer);
+
+  private HttpServer server;
+
+  @Override
+  @Before
+  public void setUp() throws Exception {
+    super.setUp();
+
+    // start the server
+    final ResourceConfig rc = (ResourceConfig) configure();
+    server = GrizzlyHttpServerFactory.createHttpServer(URI.create(BASE_URI), rc);
+  }
+
+  @Override
+  @After
+  public void tearDown() throws Exception {
+    super.tearDown();
+
+    // stop the server
+    if (server.isStarted()) {
+      server.stop();
+    }
+  }
+
+  @Override
+  protected Application configure() {
+
+    io.opentracing.Tracer serverTracer =
+        new com.uber.jaeger.Tracer
+            .Builder("server-tracer", new NoopReporter(), new ConstSampler(true))
+            .build();
+
+    TraceContext serverTraceContext = new ActiveSpanSourceTraceContext(serverTracer);
+    
+    // Our 'Application'
+    ResourceConfig resourceConfig =
+        new ResourceConfig()
+            .register(new ServerFilter(serverTracer, serverTraceContext), Priorities.USER + 10)
+            .register(new TestHookFilter(serverTraceContext), Priorities.USER + 20)
+            .register(TestResource.class);
+
+    return resourceConfig;
+  }
+
+  @After
+  public void teardownTestingInfra() {
+    // stop server
+    if (server.isStarted()) {
+      server.stop();
+    }
+  }
+
+  @Test
+  public void testTracingUsingInstrumentedClient() {
+    com.uber.jaeger.Span span = (com.uber.jaeger.Span) clientTracer
+        .buildSpan("root-span")
+        .startManual();
+    span.setBaggageItem("x-test", "testing");
+    clientTraceContext.push(span);
+
+    Response resp = target()
+        .register(new ClientFilter(clientTracer, clientTraceContext))
+        .path("test")
+        .request()
+        .header(DEBUG_JAEGER_SPAN_BAGGAGE_HEADER, "foo=bar")
+        .get();
+    assertEquals(resp.getStatus(), 200);
+  }
+
+  @Test
+  public void testTracingUsingInstrumentedClientWithFakeBaggageHeader() {
+    Response resp = target()
+        .register(new ClientFilter(clientTracer, clientTraceContext))
+        .path("test")
+        .request()
+        .header(DEBUG_JAEGER_SPAN_BAGGAGE_HEADER, "foo=bar")
+        .header("uberctx-x-test", "testing")
+        .get();
+    assertEquals(resp.getStatus(), 200);
+  }
+
+  @Test
+  public void testTracingUsingNonInstrumentedClient() {
+    Response resp = target()
+        .path("test")
+        .request()
+        .header(DEBUG_ID_HEADER_KEY, "12345")
+        .header(DEBUG_JAEGER_SPAN_BAGGAGE_HEADER, "foo=bar,x-test=testing")
+        .get();
+    assertEquals(resp.getStatus(), 200);
+  }
+
+  @Test
+  public void testTracingUsingNonInstrumentedClientWithFakeBaggageHeader() {
+    Response resp = target()
+        .path("test")
+        .request()
+        .header(DEBUG_ID_HEADER_KEY, "12345")
+        .header(DEBUG_JAEGER_SPAN_BAGGAGE_HEADER, "foo=bar")
+        .header("uberctx-x-test", "testing")
+        .get();
+    assertEquals(resp.getStatus(), 200);
+  }
+
+  @Test
+  public void testTracingUsingNonInstrumentedClientAndNoDebugId() {
+    /**
+     * this test shows that in case where there is no uber-trace-id (non-instrumented client),
+     * only way to force baggage to get populated is to include the ``"jaeger-debug-id"`` header.
+     */
+    Response resp = target()
+        .path("test")
+        .request()
+        .header(DEBUG_JAEGER_SPAN_BAGGAGE_HEADER, "foo=bar")
+        .header("uberctx-x-test", "testing")
+        .get();
+    assertEquals(resp.getStatus(), 500);
+  }
+
+  class TestHookFilter implements ContainerRequestFilter {
+
+    private final TraceContext serverTraceContext;
+
+    public TestHookFilter(TraceContext serverTraceContext) {
+      this.serverTraceContext = serverTraceContext;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+      Span curSpan = serverTraceContext.getCurrentSpan();
+
+      if (curSpan == null) {
+        requestContext.abortWith(
+            Response.status(Response.Status.UNAUTHORIZED)
+                .entity("Whoops! No span; make sure that the ServerFilter is in place")
+                .build()
+        );
+        return;
+      }
+
+      assertEquals(curSpan.getBaggageItem("x-test"), "testing");
+      assertEquals(curSpan.getBaggageItem("foo"), "bar");
+    }
+  }
+
+  @Path("test")
+  public static class TestResource {
+
+    @GET
+    public Response test(@Context ContainerRequestContext ctx) {
+      return Response.ok().build();
+    }
+  }
+}


### PR DESCRIPTION
Related to https://github.com/jaegertracing/jaeger/issues/165

Previously, presence of debug ID would not even consider baggage items populated. After I changed that behavior, I realized that the bare presence of the debug ID would cause child span to not get the baggage from list of references. Fixing both of these allowed `uberctx-*` to get populated as span baggage **iff** either ``uber-trace-id`` or ``jaeger-debug-id`` is present.
_**Awesome!**_ 🍺

Now, to maintain parity with the Go client, a new header called ``jaeger-baggage`` is being introduced. Communication to people can be that when using curl, etc to test, include both ``jaeger-debug-id`` and ``jaeger-baggage``. From my reading of the Go code, this seems to be the case (but I don't understand Go much, so I might be wrong).

Signed-off-by: Debosmit Ray <debo@uber.com>