### PR TITLE
[jaeger-client-java/jax-rs2] Remove jaeger-context dependence for JAX-RS2 jaeger instrumentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,10 +47,6 @@ allprojects {
     }
 }
 
-jacoco {
-    toolVersion = "0.8.0"
-}
-
 subprojects {
     apply plugin: 'ru.vyarus.animalsniffer'
     apply plugin: 'com.github.hierynomus.license'

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ allprojects {
     }
 }
 
+jacoco {
+    toolVersion = "0.8.0"
+}
+
 subprojects {
     apply plugin: 'ru.vyarus.animalsniffer'
     apply plugin: 'com.github.hierynomus.license'

--- a/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/JerseyServer.java
+++ b/jaeger-crossdock/src/main/java/com/uber/jaeger/crossdock/JerseyServer.java
@@ -25,6 +25,7 @@ import com.uber.jaeger.crossdock.resources.behavior.http.EndToEndBehaviorResourc
 import com.uber.jaeger.crossdock.resources.behavior.http.TraceBehaviorResource;
 import com.uber.jaeger.crossdock.resources.behavior.tchannel.TChannelServer;
 import com.uber.jaeger.crossdock.resources.health.HealthResource;
+import com.uber.jaeger.filters.jaxrs2.ClientFilter;
 import com.uber.jaeger.filters.jaxrs2.TracingUtils;
 import com.uber.jaeger.samplers.ConstSampler;
 import com.uber.jaeger.senders.HttpSender;
@@ -115,14 +116,7 @@ public class JerseyServer {
   private static Client initializeClient(final Configuration config) {
     return ClientBuilder.newClient()
         .register(ExceptionMapper.class)
-        .register(TracingUtils.clientFilter(config.getTracer()))
-        .register(
-            new AbstractBinder() {
-              @Override
-              protected void configure() {
-                bind(traceContext()).to(TraceContext.class);
-              }
-            })
+        .register(new ClientFilter(config.getTracer()))
         .register(JacksonFeature.class);
   }
 

--- a/jaeger-jaxrs2/build.gradle
+++ b/jaeger-jaxrs2/build.gradle
@@ -3,6 +3,7 @@ description = 'Instrumentation library for jaeger-jaxrs 2.0'
 dependencies {
     compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0.1'
     compile project(':jaeger-core')
+    // FIXME (debo): remove when deprecated functions are deleted
     compile project(':jaeger-context')
 
     testCompile project(path: ':jaeger-core', configuration: 'tests')

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
@@ -38,6 +38,7 @@ public class ClientFilter implements ClientRequestFilter, ClientResponseFilter {
    * @param traceContext trace context
    * @deprecated use {@link #ClientFilter(Tracer)}
    */
+  @lombok.Generated
   @Deprecated
   public ClientFilter(Tracer tracer, TraceContext traceContext) {
       this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
@@ -38,7 +38,7 @@ public class ClientFilter implements ClientRequestFilter, ClientResponseFilter {
    * @param traceContext trace context
    * @deprecated use {@link ClientFilter(Tracer)}
    */
-  @lombok.Generated
+  @lombok.Generated  // ignore deprecated code in jacoco
   @Deprecated
   public ClientFilter(Tracer tracer, TraceContext traceContext) {
       this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
@@ -36,7 +36,7 @@ public class ClientFilter implements ClientRequestFilter, ClientResponseFilter {
   /**
    * @param tracer tracer
    * @param traceContext trace context
-   * @deprecated use {@link ClientFilter(Tracer)}
+   * @deprecated use {@link #ClientFilter(Tracer)}
    */
   @Deprecated
   public ClientFilter(Tracer tracer, TraceContext traceContext) {

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
@@ -38,7 +38,7 @@ public class ClientFilter implements ClientRequestFilter, ClientResponseFilter {
    * @param traceContext trace context
    * @deprecated use {@link #ClientFilter(Tracer)}
    */
-  @lombok.Generated
+  @lombok.Generated  // ignore deprecated code in jacoco
   @Deprecated
   public ClientFilter(Tracer tracer, TraceContext traceContext) {
       this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
@@ -38,7 +38,6 @@ public class ClientFilter implements ClientRequestFilter, ClientResponseFilter {
    * @param traceContext trace context
    * @deprecated use {@link ClientFilter(Tracer)}
    */
-  @lombok.Generated  // ignore deprecated code in jacoco
   @Deprecated
   public ClientFilter(Tracer tracer, TraceContext traceContext) {
       this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
@@ -38,7 +38,6 @@ public class ClientFilter implements ClientRequestFilter, ClientResponseFilter {
    * @param traceContext trace context
    * @deprecated use {@link #ClientFilter(Tracer)}
    */
-  @lombok.Generated  // ignore deprecated code in jacoco
   @Deprecated
   public ClientFilter(Tracer tracer, TraceContext traceContext) {
       this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
@@ -38,6 +38,7 @@ public class ClientFilter implements ClientRequestFilter, ClientResponseFilter {
    * @param traceContext trace context
    * @deprecated use ClientFilter(Tracer)
    */
+  @Deprecated
   public ClientFilter(Tracer tracer, TraceContext traceContext) {
       this(tracer);
   }

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientFilter.java
@@ -36,8 +36,9 @@ public class ClientFilter implements ClientRequestFilter, ClientResponseFilter {
   /**
    * @param tracer tracer
    * @param traceContext trace context
-   * @deprecated use ClientFilter(Tracer)
+   * @deprecated use {@link ClientFilter(Tracer)}
    */
+  @lombok.Generated
   @Deprecated
   public ClientFilter(Tracer tracer, TraceContext traceContext) {
       this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanCreationFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanCreationFilter.java
@@ -14,7 +14,6 @@
 
 package com.uber.jaeger.filters.jaxrs2;
 
-import com.uber.jaeger.context.TraceContext;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanCreationFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanCreationFilter.java
@@ -37,7 +37,13 @@ public class ClientSpanCreationFilter implements ClientRequestFilter {
 
   @Override
   public void filter(ClientRequestContext clientRequestContext) throws IOException {
+    Span currentActiveSpan = tracer.activeSpan();
+
     Tracer.SpanBuilder clientSpanBuilder = tracer.buildSpan(clientRequestContext.getMethod());
+    if (currentActiveSpan != null) {
+      clientSpanBuilder.asChildOf(currentActiveSpan);
+    }
+
     Span clientSpan = clientSpanBuilder.start();
 
     // we assume there are no more spans created for this RPC request, therefore we do not need

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
@@ -40,7 +40,7 @@ public class ClientSpanInjectionFilter implements ClientRequestFilter, ClientRes
    * @param traceContext trace context
    * @deprecated use {@link ClientSpanInjectionFilter#ClientSpanInjectionFilter(Tracer)}
    */
-  @lombok.Generated
+  @lombok.Generated  // ignore deprecated code in jacoco
   @Deprecated
   public ClientSpanInjectionFilter(Tracer tracer, TraceContext traceContext) {
     this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
@@ -40,6 +40,7 @@ public class ClientSpanInjectionFilter implements ClientRequestFilter, ClientRes
    * @param traceContext trace context
    * @deprecated use {@link ClientSpanInjectionFilter#ClientSpanInjectionFilter(Tracer)}
    */
+  @lombok.Generated
   @Deprecated
   public ClientSpanInjectionFilter(Tracer tracer, TraceContext traceContext) {
     this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
@@ -40,7 +40,6 @@ public class ClientSpanInjectionFilter implements ClientRequestFilter, ClientRes
    * @param traceContext trace context
    * @deprecated use {@link ClientSpanInjectionFilter#ClientSpanInjectionFilter(Tracer)}
    */
-  @lombok.Generated  // ignore deprecated code in jacoco
   @Deprecated
   public ClientSpanInjectionFilter(Tracer tracer, TraceContext traceContext) {
     this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
@@ -40,7 +40,7 @@ public class ClientSpanInjectionFilter implements ClientRequestFilter, ClientRes
    * @param traceContext trace context
    * @deprecated use {@link ClientSpanInjectionFilter(Tracer)}
    */
-  @lombok.Generated
+  @lombok.Generated  // ignore deprecated code in jacoco
   @Deprecated
   public ClientSpanInjectionFilter(Tracer tracer, TraceContext traceContext) {
     this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
@@ -38,8 +38,9 @@ public class ClientSpanInjectionFilter implements ClientRequestFilter, ClientRes
   /**
    * @param tracer tracer
    * @param traceContext trace context
-   * @deprecated use ClientSpanInjectionFilter(Tracer)
+   * @deprecated use {@link ClientSpanInjectionFilter(Tracer)}
    */
+  @lombok.Generated
   @Deprecated
   public ClientSpanInjectionFilter(Tracer tracer, TraceContext traceContext) {
     this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
@@ -38,7 +38,7 @@ public class ClientSpanInjectionFilter implements ClientRequestFilter, ClientRes
   /**
    * @param tracer tracer
    * @param traceContext trace context
-   * @deprecated use {@link ClientSpanInjectionFilter(Tracer)}
+   * @deprecated use {@link ClientSpanInjectionFilter#ClientSpanInjectionFilter(Tracer)}
    */
   @Deprecated
   public ClientSpanInjectionFilter(Tracer tracer, TraceContext traceContext) {

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
@@ -40,7 +40,6 @@ public class ClientSpanInjectionFilter implements ClientRequestFilter, ClientRes
    * @param traceContext trace context
    * @deprecated use {@link ClientSpanInjectionFilter(Tracer)}
    */
-  @lombok.Generated  // ignore deprecated code in jacoco
   @Deprecated
   public ClientSpanInjectionFilter(Tracer tracer, TraceContext traceContext) {
     this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
@@ -17,7 +17,6 @@ package com.uber.jaeger.filters.jaxrs2;
 import com.uber.jaeger.context.TraceContext;
 
 import io.opentracing.Scope;
-import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
@@ -46,6 +45,7 @@ public class ServerFilter implements ContainerRequestFilter, ContainerResponseFi
    * @param traceContext trace context
    * @deprecated use ServerFilter(Tracer)
    */
+  @Deprecated
   public ServerFilter(Tracer tracer, TraceContext traceContext) {
     this(tracer);
   }

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
@@ -45,6 +45,7 @@ public class ServerFilter implements ContainerRequestFilter, ContainerResponseFi
    * @param traceContext trace context
    * @deprecated use {@link ServerFilter#ServerFilter(Tracer)}
    */
+  @lombok.Generated
   @Deprecated
   public ServerFilter(Tracer tracer, TraceContext traceContext) {
     this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
@@ -45,7 +45,6 @@ public class ServerFilter implements ContainerRequestFilter, ContainerResponseFi
    * @param traceContext trace context
    * @deprecated use {@link ServerFilter#ServerFilter(Tracer)}
    */
-  @lombok.Generated  // ignore deprecated code in jacoco
   @Deprecated
   public ServerFilter(Tracer tracer, TraceContext traceContext) {
     this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
@@ -45,7 +45,7 @@ public class ServerFilter implements ContainerRequestFilter, ContainerResponseFi
    * @param traceContext trace context
    * @deprecated use {@link ServerFilter(Tracer)}
    */
-  @lombok.Generated
+  @lombok.Generated  // ignore deprecated code in jacoco
   @Deprecated
   public ServerFilter(Tracer tracer, TraceContext traceContext) {
     this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
@@ -45,7 +45,6 @@ public class ServerFilter implements ContainerRequestFilter, ContainerResponseFi
    * @param traceContext trace context
    * @deprecated use {@link ServerFilter(Tracer)}
    */
-  @lombok.Generated  // ignore deprecated code in jacoco
   @Deprecated
   public ServerFilter(Tracer tracer, TraceContext traceContext) {
     this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
@@ -43,7 +43,7 @@ public class ServerFilter implements ContainerRequestFilter, ContainerResponseFi
   /**
    * @param tracer tracer
    * @param traceContext trace context
-   * @deprecated use {@link ServerFilter(Tracer)}
+   * @deprecated use {@link ServerFilter#ServerFilter(Tracer)}
    */
   @Deprecated
   public ServerFilter(Tracer tracer, TraceContext traceContext) {

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
@@ -43,8 +43,9 @@ public class ServerFilter implements ContainerRequestFilter, ContainerResponseFi
   /**
    * @param tracer tracer
    * @param traceContext trace context
-   * @deprecated use ServerFilter(Tracer)
+   * @deprecated use {@link ServerFilter(Tracer)}
    */
+  @lombok.Generated
   @Deprecated
   public ServerFilter(Tracer tracer, TraceContext traceContext) {
     this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
@@ -45,7 +45,7 @@ public class ServerFilter implements ContainerRequestFilter, ContainerResponseFi
    * @param traceContext trace context
    * @deprecated use {@link ServerFilter#ServerFilter(Tracer)}
    */
-  @lombok.Generated
+  @lombok.Generated  // ignore deprecated code in jacoco
   @Deprecated
   public ServerFilter(Tracer tracer, TraceContext traceContext) {
     this(tracer);

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
@@ -41,7 +41,8 @@ public class TracingUtils {
 
   /**
    * Returns a new client filter with the passed ``io.opentracing.Tracer``.
-   * @param tracer Tracer
+   *
+   * @param tracer tracer
    * @return ClientFilter
    * @deprecated Use {@link ClientFilter#ClientFilter(Tracer)}.
    */

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
@@ -41,7 +41,8 @@ public class TracingUtils {
 
   /**
    * Returns a new client filter with the passed ``io.opentracing.Tracer``.
-   * @param tracer Tracer
+   *
+   * @param tracer tracer
    * @return ClientFilter
    * @deprecated Use {@link ClientFilter#ClientFilter(Tracer)}.
    */
@@ -51,7 +52,9 @@ public class TracingUtils {
   }
 
   /**
-   * @deprecated Use {@link ServerFilter(Tracer)}.
+   * @param tracer tracer
+   * @return ServerFilter
+   * @deprecated Use {@link ServerFilter#ServerFilter(Tracer)}.
    */
   @Deprecated
   public static ServerFilter serverFilter(Tracer tracer) {

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
@@ -39,10 +39,18 @@ public class TracingUtils {
     return com.uber.jaeger.context.TracingUtils.tracedExecutor(wrappedExecutorService);
   }
 
+  /**
+   * @deprecated Use {@link ClientFilter(Tracer)}.
+   */
+  @Deprecated
   public static ClientFilter clientFilter(Tracer tracer) {
     return new ClientFilter(tracer);
   }
 
+  /**
+   * @deprecated Use {@link ServerFilter(Tracer)}.
+   */
+  @Deprecated
   public static ServerFilter serverFilter(Tracer tracer) {
     return new ServerFilter(tracer);
   }

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
@@ -40,7 +40,10 @@ public class TracingUtils {
   }
 
   /**
-   * @deprecated Use {@link ClientFilter(Tracer)}.
+   * Returns a new client filter with the passed ``io.opentracing.Tracer``.
+   * @param tracer Tracer
+   * @return ClientFilter
+   * @deprecated Use {@link ClientFilter#ClientFilter(Tracer)}.
    */
   @Deprecated
   public static ClientFilter clientFilter(Tracer tracer) {

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/TracingUtils.java
@@ -41,8 +41,7 @@ public class TracingUtils {
 
   /**
    * Returns a new client filter with the passed ``io.opentracing.Tracer``.
-   *
-   * @param tracer tracer
+   * @param tracer Tracer
    * @return ClientFilter
    * @deprecated Use {@link ClientFilter#ClientFilter(Tracer)}.
    */

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientFilterTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientFilterTest.java
@@ -21,8 +21,6 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.when;
 
 import com.uber.jaeger.Span;
-import com.uber.jaeger.context.ScopeManagerTraceContext;
-import com.uber.jaeger.context.TraceContext;
 import com.uber.jaeger.propagation.FilterIntegrationTest;
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.samplers.ConstSampler;
@@ -49,7 +47,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class ClientFilterTest {
 
   private Tracer tracer;
-  private TraceContext traceContext;
   private InMemoryReporter reporter;
   private ClientFilter undertest;
 
@@ -63,8 +60,7 @@ public class ClientFilterTest {
     tracer =
         new com.uber.jaeger.Tracer.Builder("Angry Machine", reporter, new ConstSampler(true))
             .build();
-    traceContext = new ScopeManagerTraceContext(tracer.scopeManager());
-    undertest = new ClientFilter(tracer, traceContext);
+    undertest = new ClientFilter(tracer);
   }
 
   @Test

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientFilterTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientFilterTest.java
@@ -60,6 +60,7 @@ public class ClientFilterTest {
     tracer =
         new com.uber.jaeger.Tracer.Builder("Angry Machine", reporter, new ConstSampler(true))
             .build();
+    // Using deprecated constructor for test coverage
     undertest = new ClientFilter(tracer, null);
   }
 

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientFilterTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientFilterTest.java
@@ -40,7 +40,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /**
- * Tests that {@link ClientFilter} produces a span and sets tags correctly See also:
+ * Tests that {@link ClientFilter} produces a span and sets tags correctly. See also:
  * {@link FilterIntegrationTest} for a complete Client/Server filter integration test
  */
 @RunWith(MockitoJUnitRunner.class)
@@ -60,7 +60,7 @@ public class ClientFilterTest {
     tracer =
         new com.uber.jaeger.Tracer.Builder("Angry Machine", reporter, new ConstSampler(true))
             .build();
-    undertest = new ClientFilter(tracer);
+    undertest = new ClientFilter(tracer, null);
   }
 
   @Test

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientFilterTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientFilterTest.java
@@ -60,7 +60,7 @@ public class ClientFilterTest {
     tracer =
         new com.uber.jaeger.Tracer.Builder("Angry Machine", reporter, new ConstSampler(true))
             .build();
-    undertest = new ClientFilter(tracer);
+    undertest = new ClientFilter(tracer, null);
   }
 
   @Test

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientFilterTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientFilterTest.java
@@ -60,7 +60,7 @@ public class ClientFilterTest {
     tracer =
         new com.uber.jaeger.Tracer.Builder("Angry Machine", reporter, new ConstSampler(true))
             .build();
-    undertest = new ClientFilter(tracer, null);
+    undertest = new ClientFilter(tracer);
   }
 
   @Test

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilterTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilterTest.java
@@ -1,0 +1,48 @@
+package com.uber.jaeger.filters.jaxrs2;
+
+import static com.uber.jaeger.filters.jaxrs2.Constants.CURRENT_SPAN_CONTEXT_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import com.uber.jaeger.reporters.InMemoryReporter;
+import com.uber.jaeger.samplers.ConstSampler;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+import java.util.Map;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClientSpanInjectionFilterTest {
+
+  private final Tracer tracer = new com.uber.jaeger.Tracer
+      .Builder("Angry Machine", new InMemoryReporter(), new ConstSampler(true))
+      .build();
+
+  @Mock
+  private ClientRequestContext clientRequestContext;
+
+  @Mock
+  private ClientResponseContext clientResponseContext;
+
+  @Test
+  public void testFilter() throws Exception {
+    // FIXME (debo): remove to use {@link ClientSpanInjectionFilter(Tracer)}
+    ClientSpanInjectionFilter filter = new ClientSpanInjectionFilter(tracer, null);
+
+    when(clientResponseContext.getStatus()).thenReturn(200);
+
+    io.opentracing.Span currentSpan = tracer.buildSpan("test").start();
+    tracer.scopeManager().activate(currentSpan, true);
+    when(clientRequestContext.getProperty(CURRENT_SPAN_CONTEXT_KEY)).thenReturn(currentSpan);
+
+    filter.filter(clientRequestContext, clientResponseContext);
+
+    Map<String, Object> tags = ((com.uber.jaeger.Span)currentSpan).getTags();
+    assertEquals(200, tags.get(Tags.HTTP_STATUS.getKey()));
+  }
+}

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilterTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilterTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) 2018, Uber Technologies, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.uber.jaeger.filters.jaxrs2;
 
 import static com.uber.jaeger.filters.jaxrs2.Constants.CURRENT_SPAN_CONTEXT_KEY;
@@ -31,15 +45,14 @@ public class ClientSpanInjectionFilterTest {
 
   @Test
   public void testFilter() throws Exception {
-    // FIXME (debo): remove to use {@link ClientSpanInjectionFilter(Tracer)}
-    ClientSpanInjectionFilter filter = new ClientSpanInjectionFilter(tracer, null);
-
     when(clientResponseContext.getStatus()).thenReturn(200);
 
     io.opentracing.Span currentSpan = tracer.buildSpan("test").start();
     tracer.scopeManager().activate(currentSpan, true);
     when(clientRequestContext.getProperty(CURRENT_SPAN_CONTEXT_KEY)).thenReturn(currentSpan);
 
+    // FIXME (debo): remove to use {@link ClientSpanInjectionFilter(Tracer)}
+    ClientSpanInjectionFilter filter = new ClientSpanInjectionFilter(tracer, null);
     filter.filter(clientRequestContext, clientResponseContext);
 
     Map<String, Object> tags = ((com.uber.jaeger.Span)currentSpan).getTags();

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilterTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilterTest.java
@@ -52,6 +52,7 @@ public class ClientSpanInjectionFilterTest {
     when(clientRequestContext.getProperty(CURRENT_SPAN_CONTEXT_KEY)).thenReturn(currentSpan);
 
     // FIXME (debo): remove to use {@link ClientSpanInjectionFilter(Tracer)}
+    // Using deprecated constructor for test coverage
     ClientSpanInjectionFilter filter = new ClientSpanInjectionFilter(tracer, null);
     filter.filter(clientRequestContext, clientResponseContext);
 

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ServerFilterTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ServerFilterTest.java
@@ -21,8 +21,6 @@ import static org.mockito.Mockito.when;
 import com.uber.jaeger.Constants;
 import com.uber.jaeger.Span;
 import com.uber.jaeger.Tracer;
-import com.uber.jaeger.context.ScopeManagerTraceContext;
-import com.uber.jaeger.context.TraceContext;
 import com.uber.jaeger.propagation.FilterIntegrationTest;
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.samplers.ConstSampler;
@@ -49,7 +47,6 @@ public class ServerFilterTest {
   private Tracer tracer;
   private InMemoryReporter reporter;
   private ServerFilter undertest;
-  private TraceContext traceContext;
 
   @Mock private ContainerRequestContext containerRequestContext;
   @Mock private ContainerResponseContext containerResponseContext;

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ServerFilterTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ServerFilterTest.java
@@ -57,7 +57,7 @@ public class ServerFilterTest {
     tracer =
         new com.uber.jaeger.Tracer.Builder("Angry Machine", reporter, new ConstSampler(true))
             .build();
-    undertest = new ServerFilter(tracer);
+    undertest = new ServerFilter(tracer, null);
   }
 
   @Test

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ServerFilterTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/filters/jaxrs2/ServerFilterTest.java
@@ -57,6 +57,7 @@ public class ServerFilterTest {
     tracer =
         new com.uber.jaeger.Tracer.Builder("Angry Machine", reporter, new ConstSampler(true))
             .build();
+    // Using deprecated constructor for test coverage
     undertest = new ServerFilter(tracer, null);
   }
 

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/FilterIntegrationTest.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/FilterIntegrationTest.java
@@ -50,7 +50,6 @@ public class FilterIntegrationTest {
   private Tracer tracer;
   private InMemoryReporter reporter;
   private InMemoryStatsReporter metricsReporter;
-  private TraceContext traceContext;
   public static final String BAGGAGE_KEY = "a-big-metal-door";
   private ObjectMapper mapper = new ObjectMapper();
 
@@ -66,15 +65,13 @@ public class FilterIntegrationTest {
             .withStatsReporter(metricsReporter)
             .build();
 
-    traceContext = new ScopeManagerTraceContext(tracer.scopeManager());
-
     // start the server
-    server = new JerseyServer(tracer, traceContext);
+    server = new JerseyServer(tracer);
     server.start();
     // create the client
     client =
         ClientBuilder.newClient()
-            .register(new ClientFilter(tracer, traceContext))
+            .register(new ClientFilter(tracer))
             .register(JacksonFeature.class);
   }
 
@@ -89,7 +86,7 @@ public class FilterIntegrationTest {
 
     Span span = (Span) tracer.buildSpan("root-span").startManual();
     span.setBaggageItem(BAGGAGE_KEY, BAGGAGE_VALUE);
-    traceContext.push(span);
+    tracer.scopeManager().activate(span, false);
 
     Response resp = target.request(MediaType.APPLICATION_JSON_TYPE).get();
 

--- a/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/JerseyServer.java
+++ b/jaeger-jaxrs2/src/test/java/com/uber/jaeger/propagation/JerseyServer.java
@@ -14,7 +14,6 @@
 
 package com.uber.jaeger.propagation;
 
-import com.uber.jaeger.context.TraceContext;
 import com.uber.jaeger.filters.jaxrs2.ServerFilter;
 import io.opentracing.Tracer;
 import java.io.IOException;
@@ -29,12 +28,10 @@ public class JerseyServer {
   // Base URI the Grizzly HTTP server will listen on
   public static final String BASE_URI = "http://localhost:8080/";
   private final Tracer tracer;
-  private final TraceContext traceContext;
   private HttpServer server;
 
-  public JerseyServer(Tracer tracer, TraceContext traceContext) throws IOException {
+  public JerseyServer(Tracer tracer) throws IOException {
     this.tracer = tracer;
-    this.traceContext = traceContext;
     server = getServer();
     server.start();
   }
@@ -54,7 +51,6 @@ public class JerseyServer {
                   @Override
                   protected void configure() {
                     bind(tracer).to(Tracer.class);
-                    bind(traceContext).to(TraceContext.class);
                   }
                 })
             .packages(JerseyHandler.class.getPackage().toString())


### PR DESCRIPTION
Have not removed from `build.gradle` since deprecated class `TracingUtils` still depends on it.