### PR TITLE
[jaeger-client-java/apache instrumentation] Completely remove apache instrumentation dependence on jaeger-context

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ ext.tracerResolverVersion = '0.1.3'
 
 ext.junitVersion = '4.12'
 ext.mockitoVersion = '2.12.0'
+ext.powermockitoVersion  = '1.7.0'
 ext.junitDataProviderVersion = '1.13.1'
 ext.awaitilityVersion = '3.0.0'
 ext.logbackVersion = '1.2.3'

--- a/jaeger-apachehttpclient/build.gradle
+++ b/jaeger-apachehttpclient/build.gradle
@@ -9,7 +9,13 @@ dependencies {
     testCompile project(path: ':jaeger-core', configuration: 'tests')
     testCompile group: 'org.mock-server', name: 'mockserver-netty', version: '3.11'
     testCompile group: 'junit', name: 'junit', version: junitVersion
-    testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
+
+    // Mockito 2.12 -> 2.8 due to PowerMock/Mockito dependency issues
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.8.0'
+    testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: '1.7.0RC2'
+    testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockitoVersion
+    testCompile group: 'org.powermock', name: 'powermock-core', version: powermockitoVersion
+    testCompile group: 'org.powermock', name: 'powermock-module-junit4-rule', version: powermockitoVersion
 
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 }

--- a/jaeger-apachehttpclient/build.gradle
+++ b/jaeger-apachehttpclient/build.gradle
@@ -2,7 +2,6 @@ description = 'Instrumentation library for apache http client'
 
 dependencies {
     compile project(':jaeger-core')
-    compile project(':jaeger-context')
     compile group: 'org.apache.httpcomponents', name: 'httpcore', version: '4.4.8'
     compile group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.3'
     compile group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '4.1.3'

--- a/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/SpanCreationRequestInterceptor.java
+++ b/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/SpanCreationRequestInterceptor.java
@@ -22,8 +22,6 @@
 
 package com.uber.jaeger.httpclient;
 
-import com.uber.jaeger.context.TraceContext;
-import com.uber.jaeger.context.TracingUtils;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
@@ -57,14 +55,14 @@ public class SpanCreationRequestInterceptor implements HttpRequestInterceptor {
   public void process(HttpRequest httpRequest, HttpContext httpContext)
       throws HttpException, IOException {
     try {
-      TraceContext parentContext = TracingUtils.getTraceContext();
+      Span currentActiveSpan = tracer.activeSpan();
 
       Tracer.SpanBuilder clientSpanBuilder = tracer.buildSpan(getOperationName(httpRequest));
-      if (!parentContext.isEmpty()) {
-        clientSpanBuilder.asChildOf(parentContext.getCurrentSpan());
+      if (currentActiveSpan != null) {
+        clientSpanBuilder.asChildOf(currentActiveSpan);
       }
 
-      Span clientSpan = clientSpanBuilder.startManual();
+      Span clientSpan = clientSpanBuilder.start();
 
       RequestLine requestLine = httpRequest.getRequestLine();
 

--- a/jaeger-apachehttpclient/src/test/java/com/uber/jaeger/httpclient/TracingRequestInterceptorTest.java
+++ b/jaeger-apachehttpclient/src/test/java/com/uber/jaeger/httpclient/TracingRequestInterceptorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018, Uber Technologies, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.uber.jaeger.httpclient;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import io.opentracing.ScopeManager;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.protocol.HttpContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(TracingRequestInterceptor.class)
+public class TracingRequestInterceptorTest {
+
+  @Test
+  public void testProcessNullScope()
+      throws Exception {
+    ScopeManager mockScopeManager = Mockito.mock(ScopeManager.class);
+    when(mockScopeManager.active()).thenReturn(null);
+
+    Tracer mockTracer = Mockito.mock(Tracer.class);
+    when(mockTracer.scopeManager()).thenReturn(mockScopeManager);
+
+    HttpRequestInterceptor interceptor = new TracingRequestInterceptor(mockTracer);
+    PowerMockito.spy(interceptor);
+
+    HttpRequest mockRequest = Mockito.mock(HttpRequest.class);
+    HttpContext mockContext = Mockito.mock(HttpContext.class);
+
+    interceptor.process(mockRequest, mockContext);
+    PowerMockito.verifyPrivate(interceptor, times(0))
+        .invoke("onSpanStarted", any(Span.class), mockRequest, mockContext);
+  }
+}


### PR DESCRIPTION
opentracing-0.31 Tracer interface completely removes the requirement for this module to depend on TracingUtils