### PR TITLE
Adding annotated filter priorities for Jersey filters

### DIFF
--- a/jaeger-jaxrs2/build.gradle
+++ b/jaeger-jaxrs2/build.gradle
@@ -1,6 +1,7 @@
 description = 'Instrumentation library for jaeger-jaxrs 2.0'
 
 dependencies {
+    compile group: 'javax.annotation', name: 'javax.annotation-api', version: '1.2-b02'
     compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0.1'
     compile project(':jaeger-core')
     // FIXME (debo): remove when deprecated functions are deleted

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanCreationFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanCreationFilter.java
@@ -18,6 +18,7 @@ import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
 import java.io.IOException;
+import javax.annotation.Priority;
 import javax.ws.rs.ConstrainedTo;
 import javax.ws.rs.RuntimeType;
 import javax.ws.rs.client.ClientRequestContext;
@@ -28,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 @Provider
 @ConstrainedTo(RuntimeType.CLIENT)
 @Slf4j
+@Priority(Constants.CLIENT_SPAN_CREATION_FILTER_PRIORITY)
 public class ClientSpanCreationFilter implements ClientRequestFilter {
   private final Tracer tracer;
 

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ClientSpanInjectionFilter.java
@@ -20,6 +20,7 @@ import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
 import java.io.IOException;
+import javax.annotation.Priority;
 import javax.ws.rs.ConstrainedTo;
 import javax.ws.rs.RuntimeType;
 import javax.ws.rs.client.ClientRequestContext;
@@ -32,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 @Provider
 @ConstrainedTo(RuntimeType.CLIENT)
 @Slf4j
+@Priority(Constants.CLIENT_SPAN_INJECTION_FILTER_PRIORITY)
 public class ClientSpanInjectionFilter implements ClientRequestFilter, ClientResponseFilter {
   private final Tracer tracer;
 

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/Constants.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/Constants.java
@@ -14,6 +14,15 @@
 
 package com.uber.jaeger.filters.jaxrs2;
 
+import javax.ws.rs.Priorities;
+
 public interface Constants {
+  /* Jersey context property tag for current active span */
   String CURRENT_SPAN_CONTEXT_KEY = "io.opentracing.Span";
+
+  /* Jersey Filter Priorites */
+  int CLIENT_SPAN_CREATION_FILTER_PRIORITY = 1;
+  int CLIENT_SPAN_INJECTION_FILTER_PRIORITY = Priorities.USER + 2000;
+
+  int SERVER_SPAN_CREATION_FILTER_PRIORITY = 1;
 }

--- a/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
+++ b/jaeger-jaxrs2/src/main/java/com/uber/jaeger/filters/jaxrs2/ServerFilter.java
@@ -22,6 +22,7 @@ import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
 import java.io.IOException;
+import javax.annotation.Priority;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
@@ -34,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Provider
 @Slf4j
+@Priority(Constants.SERVER_SPAN_CREATION_FILTER_PRIORITY)
 public class ServerFilter implements ContainerRequestFilter, ContainerResponseFilter {
   private final Tracer tracer;
 


### PR DESCRIPTION
Some open bugs in Jersey ([#2912](https://github.com/jersey/jersey/issues/2912), [#3467](https://github.com/jersey/jersey/issues/3467)) cause the framework to not honor filter binding priorities. For our internal libraries, we have found that keeping the binding priorities in the [5001, ∞) range while registering the filters keeps the ordering intact.

This change attempts to ensure that span is created very early in the request life-cycle, while giving room for consumers to manually register filters to priorities greater than `javax.ws.rs.Priorities.USER`, and yet, come before the span injection stage.

Similar idea follows for the server side instrumentation.

Signed-off-by: Debosmit Ray <debo@uber.com>