### PR TITLE
Closes #350 - Documented Micrometer integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Click through for more detailed docs on specific modules.
  * [jaeger-apachehttpclient](./jaeger-apachehttpclient): instrumentation for apache http clients
  * [jaeger-jaxrs2](./jaeger-jaxrs2): instrumentation for JAXRS2 filters
  * [jaeger-zipkin](./jaeger-zipkin): compatibility layer for using Jaeger tracer as Zipkin-compatible implementation
+ * [jaeger-micrometer](./jaeger-micrometer): a metrics provider, to report internal Jaeger metrics to third-party backends, such as Prometheus
 
 ## Importing Dependencies
 All artifacts are published to Maven Central. 

--- a/jaeger-micrometer/README.md
+++ b/jaeger-micrometer/README.md
@@ -1,0 +1,28 @@
+# Micrometer integration for Jaeger internal metrics
+
+This module brings a [Micrometer](http://micrometer.io/) integration to the internal Jaeger metrics.
+
+## Configuring
+
+To configure the Micrometer integration, a custom Jaeger Tracer instance has to be used:
+
+```java
+MicrometerMetricsFactory metricsReporter = new MicrometerMetricsFactory();
+Configuration configuration = new Configuration("myServiceName");
+Tracer tracer = configuration
+    .getTracerBuilder()
+    .withMetricsFactory(metricsReporter)
+    .build();
+```
+
+After that, just use Micrometer's API to get the data into a concrete backend via the registry mechanism. 
+For [Prometheus](https://prometheus.io/), it means using a code like the following:
+
+```java
+PrometheusMeterRegistry registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+io.micrometer.core.instrument.Metrics.addRegistry(registry);
+```
+
+Once metric data has been captured, `registry.scrape()` can be used in an endpoint accessed by Prometheus. Refer
+to the [Micrometer's documentation](http://micrometer.io/docs/concepts#_registry) on the appropriate way to achieve
+that.


### PR DESCRIPTION
Adds a README to the Micrometer module, showing how to plug it to
get internal Jaeger metrics. Shows also a complete example, from
the Java code up to how to check it on Prometheus.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>