### PR TITLE
Updating the ReporterConfig to set Sender Correctly

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/Configuration.java
@@ -570,7 +570,7 @@ public class Configuration {
     private Reporter getReporter(Metrics metrics) {
       Reporter reporter = new RemoteReporter.Builder()
           .withMetrics(metrics)
-          .withSender(senderConfiguration.sender)
+          .withSender(senderConfiguration.getSender())
           .withFlushInterval(numberOrDefault(this.flushIntervalMs, RemoteReporter.DEFAULT_FLUSH_INTERVAL_MS).intValue())
           .withMaxQueueSize(numberOrDefault(this.maxQueueSize, RemoteReporter.DEFAULT_MAX_QUEUE_SIZE).intValue())
           .build();


### PR DESCRIPTION
A small bug in the private getReporter(..) method was resulting in the sender
always being set to the default UdpSender. This is because the field
`senderConfiguration.sender` is null until the `getSender()` method is called on
it. Because the reporter builder was accessing the field directly rather than
through the getter, it was always UdpSen a null sender, thus defaulting to the
UdpSender even if the JAEGER_ENDPOINT property was set.

This commit fixes the problem, accessing the configured sender through the
appropriate getter, allowing the user configurations to propagate through to the
tracer retrieved via the `Configuration.fromEnv().getTracer()` method.

Signed-off-by: Nate Hart <nhart@tableau.com>