### PR TITLE
Avoid direct access to apache thrift from jaeger-core via transitive …

### DIFF
--- a/jaeger-core/build.gradle
+++ b/jaeger-core/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.9.0'
 
     // Testing frameworks
+    testCompile project(path: ':jaeger-thrift', configuration: 'tests')
+
     // Jersey dependencies for unit tests
     testCompile group: 'org.glassfish.jersey.test-framework.providers', name: 'jersey-test-framework-provider-grizzly2', version: jerseyVersion
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/senders/HttpSender.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/senders/HttpSender.java
@@ -29,16 +29,12 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.apache.thrift.TException;
-import org.apache.thrift.TSerializer;
-import org.apache.thrift.protocol.TBinaryProtocol;
 
-@ToString(exclude = {"httpClient", "serializer", "requestBuilder"})
+@ToString(exclude = {"httpClient", "requestBuilder"})
 public class HttpSender extends ThriftSender {
   private static final String HTTP_COLLECTOR_JAEGER_THRIFT_FORMAT_PARAM = "format=jaeger.thrift";
   private static final int ONE_MB_IN_BYTES = 1048576;
   private static final MediaType MEDIA_TYPE_THRIFT = MediaType.parse("application/x-thrift");
-  private final TSerializer serializer;
   private final OkHttpClient httpClient;
   private final Request.Builder requestBuilder;
 
@@ -57,7 +53,7 @@ public class HttpSender extends ThriftSender {
    * @param endpoint Jaeger REST endpoint consuming jaeger.thrift, e.g
    * http://localhost:14268/api/traces
    * @param maxPacketSize max bytes to serialize as payload, if 0 it will use
-   *   {@value com.uber.jaeger.reporters.protocols.ThriftUdpTransport#MAX_PACKET_SIZE}
+   *   {@value com.uber.jaeger.thrift.reporters.protocols.ThriftUdpTransport#MAX_PACKET_SIZE}
    *
    * @deprecated use {@link HttpSender.Builder} with fluent API
    */
@@ -78,7 +74,7 @@ public class HttpSender extends ThriftSender {
    * @param endpoint Jaeger REST endpoint consuming jaeger.thrift, e.g
    * http://localhost:14268/api/traces
    * @param maxPacketSize max bytes to serialize as payload, if 0 it will use
-   *   {@value com.uber.jaeger.reporters.protocols.ThriftUdpTransport#MAX_PACKET_SIZE}
+   *   {@value com.uber.jaeger.thrift.reporters.protocols.ThriftUdpTransport#MAX_PACKET_SIZE}
    * @param client a client used to make http requests
    * @deprecated use {@link HttpSender.Builder} with fluent API
    */
@@ -90,7 +86,7 @@ public class HttpSender extends ThriftSender {
   }
 
   private HttpSender(Builder builder) {
-    super(new TBinaryProtocol.Factory(), builder.maxPacketSize);
+    super(ProtocolType.Binary, builder.maxPacketSize);
     HttpUrl collectorUrl = HttpUrl
         .parse(String.format("%s?%s", builder.endpoint, HTTP_COLLECTOR_JAEGER_THRIFT_FORMAT_PARAM));
     if (collectorUrl == null) {
@@ -98,13 +94,12 @@ public class HttpSender extends ThriftSender {
     }
     this.httpClient = builder.clientBuilder.build();
     this.requestBuilder = new Request.Builder().url(collectorUrl);
-    this.serializer = new TSerializer(protocolFactory);
   }
 
   @Override
-  public void send(Process process, List<Span> spans) throws TException {
+  public void send(Process process, List<Span> spans) throws Exception {
     Batch batch = new Batch(process, spans);
-    byte[] bytes = serializer.serialize(batch);
+    byte[] bytes = serialize(batch);
 
     RequestBody body = RequestBody.create(MEDIA_TYPE_THRIFT, bytes);
     Request request = requestBuilder.post(body).build();
@@ -112,7 +107,7 @@ public class HttpSender extends ThriftSender {
     try {
       response = httpClient.newCall(request).execute();
     } catch (IOException e) {
-      throw new TException(String.format("Could not send %d spans", spans.size()), e);
+      throw new Exception(String.format("Could not send %d spans", spans.size()), e);
     }
 
     if (!response.isSuccessful()) {
@@ -125,7 +120,7 @@ public class HttpSender extends ThriftSender {
 
       String exceptionMessage = String.format("Could not send %d spans, response %d: %s",
           spans.size(), response.code(), responseBody);
-      throw new TException(exceptionMessage);
+      throw new Exception(exceptionMessage);
     }
   }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/senders/ThriftSender.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/senders/ThriftSender.java
@@ -90,7 +90,7 @@ public abstract class ThriftSender extends ThriftSenderBase implements Sender {
     return n;
   }
 
-  public abstract void send(Process process, List<com.uber.jaeger.thriftjava.Span> spans) throws Exception;
+  public abstract void send(Process process, List<com.uber.jaeger.thriftjava.Span> spans) throws SenderException;
 
   @Override
   public int flush() throws SenderException {
@@ -101,7 +101,7 @@ public abstract class ThriftSender extends ThriftSenderBase implements Sender {
     int n = spanBuffer.size();
     try {
       send(process, spanBuffer);
-    } catch (Exception e) {
+    } catch (SenderException e) {
       throw new SenderException("Failed to flush spans.", e, n);
     } finally {
       spanBuffer.clear();

--- a/jaeger-core/src/main/java/com/uber/jaeger/senders/ThriftSender.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/senders/ThriftSender.java
@@ -17,67 +17,61 @@ package com.uber.jaeger.senders;
 import com.uber.jaeger.Span;
 import com.uber.jaeger.exceptions.SenderException;
 import com.uber.jaeger.reporters.protocols.JaegerThriftSpanConverter;
-import com.uber.jaeger.reporters.protocols.ThriftUdpTransport;
+import com.uber.jaeger.thrift.reporters.protocols.ThriftUdpTransport;
+import com.uber.jaeger.thrift.senders.ThriftSenderBase;
 import com.uber.jaeger.thriftjava.Process;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.ToString;
-import org.apache.thrift.TBase;
-import org.apache.thrift.TException;
-import org.apache.thrift.protocol.TProtocolFactory;
-import org.apache.thrift.transport.AutoExpandingBufferWriteTransport;
 
-@ToString(exclude = {"spanBuffer", "memoryTransport"})
-public abstract class ThriftSender implements Sender {
-  static final int EMIT_BATCH_OVERHEAD = 33;
+import lombok.ToString;
+
+@ToString(exclude = {"spanBuffer"})
+public abstract class ThriftSender extends ThriftSenderBase implements Sender {
 
   private Process process;
   private int processBytesSize;
   private List<com.uber.jaeger.thriftjava.Span> spanBuffer;
   private int byteBufferSize;
-  private AutoExpandingBufferWriteTransport memoryTransport;
-
-  protected final TProtocolFactory protocolFactory;
-  private final int maxSpanBytes;
 
   /**
-   * @param protocolFactory protocol factory
+   * @param protocolType protocol type (compact or binary)
    * @param maxPacketSize if 0 it will use default value {@value ThriftUdpTransport#MAX_PACKET_SIZE}
    */
-  public ThriftSender(TProtocolFactory protocolFactory, int maxPacketSize) {
-    this.protocolFactory = protocolFactory;
+  public ThriftSender(ProtocolType protocolType, int maxPacketSize) {
+    super(protocolType, maxPacketSize);
 
-    if (maxPacketSize == 0) {
-      maxPacketSize = ThriftUdpTransport.MAX_PACKET_SIZE;
-    }
-
-    memoryTransport = new AutoExpandingBufferWriteTransport(maxPacketSize, 2);
-    maxSpanBytes = maxPacketSize - EMIT_BATCH_OVERHEAD;
     spanBuffer = new ArrayList<com.uber.jaeger.thriftjava.Span>();
   }
-
-  public abstract void send(Process process, List<com.uber.jaeger.thriftjava.Span> spans) throws TException;
 
   @Override
   public int append(Span span) throws SenderException {
     if (process == null) {
-      process = new Process(span.getTracer().getServiceName());
-      process.setTags(JaegerThriftSpanConverter.buildTags(span.getTracer().tags()));
-      processBytesSize = getSizeOfSerializedThrift(process);
-      byteBufferSize += processBytesSize;
+      try {
+        process = new Process(span.getTracer().getServiceName());
+        process.setTags(JaegerThriftSpanConverter.buildTags(span.getTracer().tags()));
+        processBytesSize = getSize(process);
+        byteBufferSize += processBytesSize;
+      } catch (Exception e) {
+        throw new SenderException("ThriftSender failed writing Process to memory buffer.", e, 1);
+      }
     }
 
     com.uber.jaeger.thriftjava.Span thriftSpan = JaegerThriftSpanConverter.convertSpan(span);
-    int spanSize = getSizeOfSerializedThrift(thriftSpan);
-    if (spanSize > maxSpanBytes) {
+    int spanSize = 0;
+    try {
+      spanSize = getSize(thriftSpan);
+    } catch (Exception e) {
+      throw new SenderException("ThriftSender failed writing Span to memory buffer.", e, 1);
+    }
+    if (spanSize > getMaxSpanBytes()) {
       throw new SenderException(String.format("ThriftSender received a span that was too large, size = %d, max = %d",
-          spanSize, maxSpanBytes), null, 1);
+          spanSize, getMaxSpanBytes()), null, 1);
     }
 
     byteBufferSize += spanSize;
-    if (byteBufferSize <= maxSpanBytes) {
+    if (byteBufferSize <= getMaxSpanBytes()) {
       spanBuffer.add(thriftSpan);
-      if (byteBufferSize < maxSpanBytes) {
+      if (byteBufferSize < getMaxSpanBytes()) {
         return 0;
       }
       return flush();
@@ -96,6 +90,8 @@ public abstract class ThriftSender implements Sender {
     return n;
   }
 
+  public abstract void send(Process process, List<com.uber.jaeger.thriftjava.Span> spans) throws Exception;
+
   @Override
   public int flush() throws SenderException {
     if (spanBuffer.isEmpty()) {
@@ -105,7 +101,7 @@ public abstract class ThriftSender implements Sender {
     int n = spanBuffer.size();
     try {
       send(process, spanBuffer);
-    } catch (TException e) {
+    } catch (Exception e) {
       throw new SenderException("Failed to flush spans.", e, n);
     } finally {
       spanBuffer.clear();
@@ -119,13 +115,4 @@ public abstract class ThriftSender implements Sender {
     return flush();
   }
 
-  int getSizeOfSerializedThrift(TBase thriftBase) throws SenderException {
-    memoryTransport.reset();
-    try {
-      thriftBase.write(protocolFactory.getProtocol(memoryTransport));
-    } catch (TException e) {
-      throw new SenderException("ThriftSender failed writing to memory buffer.", e, 1);
-    }
-    return memoryTransport.getPos();
-  }
 }

--- a/jaeger-core/src/main/java/com/uber/jaeger/senders/UdpSender.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/senders/UdpSender.java
@@ -59,8 +59,12 @@ public class UdpSender extends ThriftSender {
   }
 
   @Override
-  public void send(Process process, List<com.uber.jaeger.thriftjava.Span> spans) throws Exception {
-    agentClient.emitBatch(new Batch(process, spans));
+  public void send(Process process, List<com.uber.jaeger.thriftjava.Span> spans) throws SenderException {
+    try {
+      agentClient.emitBatch(new Batch(process, spans));
+    } catch (Exception e) {
+      throw new SenderException(String.format("Could not send %d spans", spans.size()), e, 1);
+    }
   }
 
   @Override

--- a/jaeger-core/src/main/java/com/uber/jaeger/senders/UdpSender.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/senders/UdpSender.java
@@ -16,13 +16,11 @@ package com.uber.jaeger.senders;
 
 import com.uber.jaeger.agent.thrift.Agent;
 import com.uber.jaeger.exceptions.SenderException;
-import com.uber.jaeger.reporters.protocols.ThriftUdpTransport;
+import com.uber.jaeger.thrift.reporters.protocols.ThriftUdpTransport;
 import com.uber.jaeger.thriftjava.Batch;
 import com.uber.jaeger.thriftjava.Process;
 import java.util.List;
 import lombok.ToString;
-import org.apache.thrift.TException;
-import org.apache.thrift.protocol.TCompactProtocol;
 
 @ToString(exclude = {"agentClient"})
 public class UdpSender extends ThriftSender {
@@ -46,7 +44,7 @@ public class UdpSender extends ThriftSender {
    * @param maxPacketSize if 0 it will use {@value ThriftUdpTransport#MAX_PACKET_SIZE}
    */
   public UdpSender(String host, int port, int maxPacketSize) {
-    super(new TCompactProtocol.Factory(), maxPacketSize);
+    super(ProtocolType.Compact, maxPacketSize);
 
     if (host == null || host.length() == 0) {
       host = DEFAULT_AGENT_UDP_HOST;
@@ -61,7 +59,7 @@ public class UdpSender extends ThriftSender {
   }
 
   @Override
-  public void send(Process process, List<com.uber.jaeger.thriftjava.Span> spans) throws TException {
+  public void send(Process process, List<com.uber.jaeger.thriftjava.Span> spans) throws Exception {
     agentClient.emitBatch(new Batch(process, spans));
   }
 

--- a/jaeger-core/src/main/java/com/uber/jaeger/senders/UdpSender.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/senders/UdpSender.java
@@ -63,7 +63,7 @@ public class UdpSender extends ThriftSender {
     try {
       agentClient.emitBatch(new Batch(process, spans));
     } catch (Exception e) {
-      throw new SenderException(String.format("Could not send %d spans", spans.size()), e, 1);
+      throw new SenderException(String.format("Could not send %d spans", spans.size()), e, spans.size());
     }
   }
 

--- a/jaeger-core/src/test/java/com/uber/jaeger/senders/HttpSenderTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/senders/HttpSenderTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.uber.jaeger.Configuration;
+import com.uber.jaeger.exceptions.SenderException;
 import com.uber.jaeger.thriftjava.Process;
 import com.uber.jaeger.thriftjava.Span;
 
@@ -85,6 +86,12 @@ public class HttpSenderTest extends JerseyTest {
   public void serverDoesntExist() throws Exception {
     HttpSender sender = new HttpSender("http://some-server/api/traces");
     sender.send(new Process("robotrock"), generateSpans());
+  }
+
+  @Test(expected = SenderException.class)
+  public void senderFail() throws Exception {
+    HttpSender sender = new HttpSender("http://some-server/api/traces");
+    sender.send(null, generateSpans());
   }
 
   @Test

--- a/jaeger-core/src/test/java/com/uber/jaeger/senders/HttpSenderTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/senders/HttpSenderTest.java
@@ -33,7 +33,6 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Response;
 
 import okhttp3.OkHttpClient;
-import org.apache.thrift.TException;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Before;
@@ -71,7 +70,7 @@ public class HttpSenderTest extends JerseyTest {
         .send(new Process("name"), generateSpans());
   }
 
-  @Test(expected = TException.class)
+  @Test(expected = Exception.class)
   public void sendServerError() throws Exception {
     HttpSender sender = new HttpSender(target("/api/tracesErr").getUri().toString());
     sender.send(new Process("robotrock"), generateSpans());
@@ -82,7 +81,7 @@ public class HttpSenderTest extends JerseyTest {
     new HttpSender("misconfiguredUrl");
   }
 
-  @Test(expected = TException.class)
+  @Test(expected = Exception.class)
   public void serverDoesntExist() throws Exception {
     HttpSender sender = new HttpSender("http://some-server/api/traces");
     sender.send(new Process("robotrock"), generateSpans());
@@ -125,7 +124,7 @@ public class HttpSenderTest extends JerseyTest {
     try {
       sender.send(new Process("robotrock"), generateSpans());
       fail("expecting exception");
-    } catch (TException te) {
+    } catch (Exception te) {
       assertTrue(te.getMessage().contains("response 401"));
     }
   }

--- a/jaeger-core/src/test/java/com/uber/jaeger/senders/ThriftSenderTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/senders/ThriftSenderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017-2018, The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.uber.jaeger.senders;
+
+import com.uber.jaeger.exceptions.SenderException;
+import com.uber.jaeger.thrift.senders.ThriftSenderBase.ProtocolType;
+import com.uber.jaeger.thriftjava.Process;
+import com.uber.jaeger.thriftjava.Span;
+
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * This class tests the abstract ThriftSender.
+ */
+public class ThriftSenderTest {
+
+  @Test(expected = SenderException.class)
+  public void calculateProcessSizeNull() throws Exception {
+    ThriftSender sender = new ThriftSender(ProtocolType.Compact, 0) {
+      @Override
+      public void send(Process process, List<Span> spans) throws SenderException {
+      }
+    };
+
+    sender.calculateProcessSize(null);
+  }
+
+  @Test(expected = SenderException.class)
+  public void calculateSpanSizeNull() throws Exception {
+    ThriftSender sender = new ThriftSender(ProtocolType.Compact, 0) {
+      @Override
+      public void send(Process process, List<Span> spans) throws SenderException {
+      }
+    };
+
+    sender.calculateSpanSize(null);
+  }
+
+}

--- a/jaeger-core/src/test/java/com/uber/jaeger/senders/UdpSenderTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/senders/UdpSenderTest.java
@@ -20,23 +20,18 @@ import static org.junit.Assert.assertTrue;
 
 import com.uber.jaeger.Span;
 import com.uber.jaeger.Tracer;
-import com.uber.jaeger.agent.thrift.Agent;
 import com.uber.jaeger.exceptions.SenderException;
 import com.uber.jaeger.metrics.InMemoryStatsReporter;
 import com.uber.jaeger.reporters.InMemoryReporter;
 import com.uber.jaeger.reporters.Reporter;
 import com.uber.jaeger.reporters.protocols.JaegerThriftSpanConverter;
-import com.uber.jaeger.reporters.protocols.TestTServer;
 import com.uber.jaeger.samplers.ConstSampler;
+import com.uber.jaeger.thrift.reporters.protocols.TestTServer;
 import com.uber.jaeger.thriftjava.Batch;
 import com.uber.jaeger.thriftjava.Process;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.thrift.protocol.TCompactProtocol;
-import org.apache.thrift.transport.AutoExpandingBufferWriteTransport;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -114,14 +109,8 @@ public class UdpSenderTest {
     Process process = new Process(tracer.getServiceName())
         .setTags(JaegerThriftSpanConverter.buildTags(tracer.tags()));
 
-    AutoExpandingBufferWriteTransport memoryTransport =
-        new AutoExpandingBufferWriteTransport(maxPacketSize, 2);
-
-    process.write(new TCompactProtocol(memoryTransport));
-    int processSize = memoryTransport.getPos();
-    memoryTransport.reset();
-    span.write(new TCompactProtocol((memoryTransport)));
-    int spanSize = memoryTransport.getPos();
+    int processSize = sender.getSize(process);
+    int spanSize = sender.getSize(span);
 
     // create a sender thats a multiple of the span size (accounting for span overhead)
     // this allows us to test the boundary conditions of writing spans.
@@ -168,38 +157,4 @@ public class UdpSenderTest {
     assertEquals("ip", batch.getProcess().getTags().get(3).getKey());
   }
 
-  @Test
-  public void testEmitBatchOverhead() throws Exception {
-    int a = calculateBatchOverheadDifference(1);
-    int b = calculateBatchOverheadDifference(2);
-
-    // This value has been empirically observed to be 56.
-    // If this test breaks it means we have changed our protocol, or
-    // the protocol information has changed (likely due to a new version of thrift).
-    assertEquals(a, b);
-    assertEquals(b, UdpSender.EMIT_BATCH_OVERHEAD);
-  }
-
-  private int calculateBatchOverheadDifference(int numberOfSpans) throws Exception {
-    AutoExpandingBufferWriteTransport memoryTransport =
-        new AutoExpandingBufferWriteTransport(maxPacketSize, 2);
-    Agent.Client memoryClient = new Agent.Client(new TCompactProtocol((memoryTransport)));
-    Span jaegerSpan = (Span) tracer.buildSpan("raza").startManual();
-    com.uber.jaeger.thriftjava.Span span = JaegerThriftSpanConverter.convertSpan(jaegerSpan);
-    List<com.uber.jaeger.thriftjava.Span> spans = new ArrayList<>();
-    for (int i = 0; i < numberOfSpans; i++) {
-      spans.add(span);
-    }
-
-    memoryClient.emitBatch(new Batch(new Process(SERVICE_NAME), spans));
-    int emitBatchOverheadMultipleSpans = memoryTransport.getPos();
-
-    memoryTransport.reset();
-    for (int j = 0; j < numberOfSpans; j++) {
-      span.write(new TCompactProtocol(memoryTransport));
-    }
-    int writeBatchOverheadMultipleSpans = memoryTransport.getPos();
-
-    return emitBatchOverheadMultipleSpans - writeBatchOverheadMultipleSpans;
-  }
 }

--- a/jaeger-core/src/test/java/com/uber/jaeger/senders/UdpSenderTest.java
+++ b/jaeger-core/src/test/java/com/uber/jaeger/senders/UdpSenderTest.java
@@ -30,6 +30,7 @@ import com.uber.jaeger.thrift.reporters.protocols.TestTServer;
 import com.uber.jaeger.thriftjava.Batch;
 import com.uber.jaeger.thriftjava.Process;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
@@ -155,6 +156,11 @@ public class UdpSenderTest {
     assertEquals("jaeger.version", batch.getProcess().getTags().get(1).getKey());
     assertEquals("bar", batch.getProcess().getTags().get(2).getVStr());
     assertEquals("ip", batch.getProcess().getTags().get(3).getKey());
+  }
+
+  @Test(expected = SenderException.class)
+  public void senderFail() throws Exception {
+    sender.send(null, Collections.emptyList());
   }
 
 }

--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -8,6 +8,8 @@ description = 'Generated thrift code'
 dependencies {
     compile group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
 
+    testCompile group: 'junit', name: 'junit', version: junitVersion
+
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 }
 
@@ -41,8 +43,18 @@ shadowJar {
     classifier 'thrift92'
 }
 
+task testJar(type: Jar, dependsOn: testClasses) {
+    baseName = "test-${project.archivesBaseName}"
+    from sourceSets.test.output
+}
+
+configurations {
+    tests
+}
+
 artifacts {
     archives(shadowJar.archivePath) {
         builtBy shadowJar
     }
+    tests testJar
 }

--- a/jaeger-thrift/src/main/java/com/uber/jaeger/thrift/reporters/protocols/ThriftUdpTransport.java
+++ b/jaeger-thrift/src/main/java/com/uber/jaeger/thrift/reporters/protocols/ThriftUdpTransport.java
@@ -12,7 +12,7 @@
  * the License.
  */
 
-package com.uber.jaeger.reporters.protocols;
+package com.uber.jaeger.thrift.reporters.protocols;
 
 import java.io.Closeable;
 import java.io.IOException;

--- a/jaeger-thrift/src/main/java/com/uber/jaeger/thrift/senders/ThriftSenderBase.java
+++ b/jaeger-thrift/src/main/java/com/uber/jaeger/thrift/senders/ThriftSenderBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018, Uber Technologies, Inc
+ * Copyright (c) 2016-2018, The Jaeger Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/jaeger-thrift/src/main/java/com/uber/jaeger/thrift/senders/ThriftSenderBase.java
+++ b/jaeger-thrift/src/main/java/com/uber/jaeger/thrift/senders/ThriftSenderBase.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016-2018, Uber Technologies, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.uber.jaeger.thrift.senders;
+
+import com.uber.jaeger.thrift.reporters.protocols.ThriftUdpTransport;
+
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.thrift.TBase;
+import org.apache.thrift.TSerializer;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TCompactProtocol;
+import org.apache.thrift.protocol.TProtocolFactory;
+import org.apache.thrift.transport.AutoExpandingBufferWriteTransport;
+
+@ToString(exclude = {"memoryTransport"})
+@Slf4j
+public abstract class ThriftSenderBase {
+
+  protected enum ProtocolType {
+    Binary,
+    Compact
+  }
+
+  public static final int EMIT_BATCH_OVERHEAD = 33;
+
+  private AutoExpandingBufferWriteTransport memoryTransport;
+
+  protected final TProtocolFactory protocolFactory;
+  private final TSerializer serializer;
+  private final int maxSpanBytes;
+
+  /**
+   * @param protocolType protocol type (compact or binary)
+   * @param maxPacketSize if 0 it will use default value {@value ThriftUdpTransport#MAX_PACKET_SIZE}
+   */
+  public ThriftSenderBase(ProtocolType protocolType, int maxPacketSize) {
+    switch (protocolType) {
+      case Binary:
+        this.protocolFactory = new TBinaryProtocol.Factory();
+        break;
+      case Compact:
+        this.protocolFactory = new TCompactProtocol.Factory();
+        break;
+      default:
+        this.protocolFactory = null;
+        log.error("Unknown thrift protocol type specified: " + protocolType);
+        break;
+    }
+
+    if (maxPacketSize == 0) {
+      maxPacketSize = ThriftUdpTransport.MAX_PACKET_SIZE;
+    }
+
+    maxSpanBytes = maxPacketSize - EMIT_BATCH_OVERHEAD;
+    memoryTransport = new AutoExpandingBufferWriteTransport(maxPacketSize, 2);
+    serializer = new TSerializer(protocolFactory);
+  }
+
+  protected int getMaxSpanBytes() {
+    return maxSpanBytes;
+  }
+
+  protected byte[] serialize(TBase<?,?> thriftBase) throws Exception {
+    return serializer.serialize(thriftBase);
+  }
+
+  public int getSize(TBase<?,?> thriftBase) throws Exception {
+    memoryTransport.reset();
+    thriftBase.write(protocolFactory.getProtocol(memoryTransport));
+    return memoryTransport.getPos();
+  }
+
+}

--- a/jaeger-thrift/src/main/java/com/uber/jaeger/thrift/senders/ThriftSenderBase.java
+++ b/jaeger-thrift/src/main/java/com/uber/jaeger/thrift/senders/ThriftSenderBase.java
@@ -30,7 +30,7 @@ import org.apache.thrift.transport.AutoExpandingBufferWriteTransport;
 @Slf4j
 public abstract class ThriftSenderBase {
 
-  protected enum ProtocolType {
+  public enum ProtocolType {
     Binary,
     Compact
   }

--- a/jaeger-thrift/src/test/java/com/uber/jaeger/thrift/reporters/protocols/InMemorySpanServerHandler.java
+++ b/jaeger-thrift/src/test/java/com/uber/jaeger/thrift/reporters/protocols/InMemorySpanServerHandler.java
@@ -12,7 +12,7 @@
  * the License.
  */
 
-package com.uber.jaeger.reporters.protocols;
+package com.uber.jaeger.thrift.reporters.protocols;
 
 import com.twitter.zipkin.thriftjava.Span;
 import com.uber.jaeger.agent.thrift.Agent;

--- a/jaeger-thrift/src/test/java/com/uber/jaeger/thrift/reporters/protocols/TestTServer.java
+++ b/jaeger-thrift/src/test/java/com/uber/jaeger/thrift/reporters/protocols/TestTServer.java
@@ -12,7 +12,7 @@
  * the License.
  */
 
-package com.uber.jaeger.reporters.protocols;
+package com.uber.jaeger.thrift.reporters.protocols;
 
 import com.uber.jaeger.agent.thrift.Agent;
 import com.uber.jaeger.thriftjava.Batch;

--- a/jaeger-thrift/src/test/java/com/uber/jaeger/thrift/reporters/protocols/ThriftSenderBaseTest.java
+++ b/jaeger-thrift/src/test/java/com/uber/jaeger/thrift/reporters/protocols/ThriftSenderBaseTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2016-2018, Uber Technologies, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.uber.jaeger.thrift.reporters.protocols;
+
+import static org.junit.Assert.assertEquals;
+import com.uber.jaeger.agent.thrift.Agent;
+import com.uber.jaeger.thrift.senders.ThriftSenderBase;
+import com.uber.jaeger.thriftjava.Batch;
+import com.uber.jaeger.thriftjava.Process;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.thrift.protocol.TCompactProtocol;
+import org.apache.thrift.transport.AutoExpandingBufferWriteTransport;
+import org.junit.Test;
+
+public class ThriftSenderBaseTest {
+  static final String SERVICE_NAME = "test-sender";
+  final int maxPacketSize = 1000;
+
+  @Test
+  public void testEmitBatchOverhead() throws Exception {
+    int a = calculateBatchOverheadDifference(1);
+    int b = calculateBatchOverheadDifference(2);
+
+    // This value has been empirically observed to be 56.
+    // If this test breaks it means we have changed our protocol, or
+    // the protocol information has changed (likely due to a new version of thrift).
+    assertEquals(a, b);
+    assertEquals(b, ThriftSenderBase.EMIT_BATCH_OVERHEAD);
+  }
+
+  private int calculateBatchOverheadDifference(int numberOfSpans) throws Exception {
+    AutoExpandingBufferWriteTransport memoryTransport =
+        new AutoExpandingBufferWriteTransport(maxPacketSize, 2);
+    Agent.Client memoryClient = new Agent.Client(new TCompactProtocol((memoryTransport)));
+    com.uber.jaeger.thriftjava.Span span = new com.uber.jaeger.thriftjava.Span();
+    span.setOperationName("raza");
+        //0, 0, 0, 0, "raza", 0, 0, 0);
+    List<com.uber.jaeger.thriftjava.Span> spans = new ArrayList<>();
+    for (int i = 0; i < numberOfSpans; i++) {
+      spans.add(span);
+    }
+
+    memoryClient.emitBatch(new Batch(new Process(SERVICE_NAME), spans));
+    int emitBatchOverheadMultipleSpans = memoryTransport.getPos();
+
+    memoryTransport.reset();
+    for (int j = 0; j < numberOfSpans; j++) {
+      span.write(new TCompactProtocol(memoryTransport));
+    }
+    int writeBatchOverheadMultipleSpans = memoryTransport.getPos();
+
+    return emitBatchOverheadMultipleSpans - writeBatchOverheadMultipleSpans;
+  }
+}

--- a/jaeger-thrift/src/test/java/com/uber/jaeger/thrift/reporters/protocols/ThriftSenderBaseTest.java
+++ b/jaeger-thrift/src/test/java/com/uber/jaeger/thrift/reporters/protocols/ThriftSenderBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018, Uber Technologies, Inc
+ * Copyright (c) 2016-2018, The Jaeger Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -34,7 +34,7 @@ public class ThriftSenderBaseTest {
     int a = calculateBatchOverheadDifference(1);
     int b = calculateBatchOverheadDifference(2);
 
-    // This value has been empirically observed to be 56.
+    // This value has been empirically observed and defined in ThriftSenderBase.EMIT_BATCH_OVERHEAD.
     // If this test breaks it means we have changed our protocol, or
     // the protocol information has changed (likely due to a new version of thrift).
     assertEquals(a, b);

--- a/jaeger-thrift/src/test/java/com/uber/jaeger/thrift/reporters/protocols/ThriftUdpServerTransport.java
+++ b/jaeger-thrift/src/test/java/com/uber/jaeger/thrift/reporters/protocols/ThriftUdpServerTransport.java
@@ -12,13 +12,15 @@
  * the License.
  */
 
-package com.uber.jaeger.reporters.protocols;
+package com.uber.jaeger.thrift.reporters.protocols;
 
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import org.apache.thrift.transport.TServerTransport;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
+
+import com.uber.jaeger.thrift.reporters.protocols.ThriftUdpTransport;
 
 public class ThriftUdpServerTransport extends TServerTransport {
   private ThriftUdpTransport transport;


### PR DESCRIPTION
…dependency through jaeger-thrift.

Fixes #228 

Aim is to minimise changes while removing all direct usage of Apache Thrift from jaeger-core.

Signed-off-by: Gary Brown <gary@brownuk.com>