### PR TITLE
HttpSenderBuilder define some methods as public

### DIFF
--- a/jaeger-core/src/main/java/com/uber/jaeger/senders/HttpSender.java
+++ b/jaeger-core/src/main/java/com/uber/jaeger/senders/HttpSender.java
@@ -139,12 +139,12 @@ public class HttpSender extends ThriftSender {
       this.endpoint = endpoint;
     }
 
-    private Builder withClient(OkHttpClient client) {
+    public Builder withClient(OkHttpClient client) {
       this.clientBuilder = client.newBuilder();
       return this;
     }
 
-    private Builder withMaxPacketSize(int maxPacketSizeBytes) {
+    public Builder withMaxPacketSize(int maxPacketSizeBytes) {
       this.maxPacketSize = maxPacketSizeBytes;
       return this;
     }


### PR DESCRIPTION
Related to https://github.com/opentracing-contrib/java-spring-cloud/pull/113#discussion_r179199532

Signed-off-by: Pavol Loffay <ploffay@redhat.com>