### PR TITLE
[jaeger/apache-http-instrumentation] TracingRequestInterceptor gets span from http request context vs tracer scope manager

### DIFF
--- a/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/TracingRequestInterceptor.java
+++ b/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/TracingRequestInterceptor.java
@@ -14,7 +14,6 @@
 
 package com.uber.jaeger.httpclient;
 
-import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import java.io.IOException;
@@ -50,11 +49,11 @@ public class TracingRequestInterceptor implements HttpRequestInterceptor {
     try {
       spanCreationInterceptor.process(httpRequest, httpContext);
 
-      Scope currentScope = tracer.scopeManager().active();
-      if (currentScope != null) {
-        onSpanStarted(currentScope.span(), httpRequest, httpContext);
+      Span clientSpan = (Span) httpContext.getAttribute(Constants.CURRENT_SPAN_CONTEXT_KEY);
+      if (clientSpan != null) {
+        onSpanStarted(clientSpan, httpRequest, httpContext);
       } else {
-        log.warn("Current scope is null; possibly failed to start client tracing span.");
+        log.warn("Current client span is null; SpanCreationRequestInterceptor possibly failed to start client tracing span.");
       }
 
       spanInjectionInterceptor.process(httpRequest, httpContext);


### PR DESCRIPTION
[`SpanCreationRequestInterceptor#process`](https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/SpanCreationRequestInterceptor.java#L55) creates a new span for the outbound request and
stores it as attribute in http context
```
...
httpContext.setAttribute(Constants.CURRENT_SPAN_CONTEXT_KEY, clientSpan);
```

Point to be noted here is that this newly created span is _not marked as the current
active span_ in the tracer's scope manager (which is totally fine). [`TracingRequestInterceptor`](https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/TracingRequestInterceptor.java#L36)
was trying to access this very span from the tracer's scope manager (which is not guaranteed
to be not-null). Clearly, [`TracingRequestInterceptor`](https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-apachehttpclient/src/main/java/com/uber/jaeger/httpclient/TracingRequestInterceptor.java#L53) should be trying to access the current
span from the context of the current outbound request and **not** the tracer's thread local storage.

Signed-off-by: Debosmit Ray <debo@uber.com>