### PR TITLE
Pin release version 0.27.0-RC1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.17.0'
 }
 
-ext.developmentVersion = '0.26.1-SNAPSHOT'
+ext.developmentVersion = '0.27.0-RC1'
 
 ext.opentracingVersion = '0.31.0'
 ext.guavaVersion = '18.0'


### PR DESCRIPTION
Trying to pin release version, RELEASE readme does not say so but git history shows that it people were doing it. 

Related to #390 


Signed-off-by: Pavol Loffay <ploffay@redhat.com>