### PR TITLE
Define okhttp version in top level build.gradle, along with other dep…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ ext.slf4jVersion = getProperty('slf4jVersion','1.7.25')
 ext.gsonVersion = getProperty('gsonVersion','2.8.2')
 ext.tracerResolverVersion = getProperty('tracerResolverVersion','0.1.4')
 ext.micrometerVersion = getProperty('micrometerVersion','1.0.0')
+ext.okhttpVersion = getProperty('okhttpVersion','3.9.0')
 
 ext.junitVersion = '4.12'
 ext.mockitoVersion = '2.12.0'

--- a/jaeger-core/build.gradle
+++ b/jaeger-core/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile group: 'io.opentracing', name: 'opentracing-util', version: opentracingVersion
     compile group: 'com.google.code.gson', name: 'gson', version: gsonVersion
     compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
-    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.9.0'
+    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion
 
     // Testing frameworks
     testCompile project(path: ':jaeger-thrift', configuration: 'tests')


### PR DESCRIPTION
…endencies

Follow on from #397 - to include missed okhttp dependency.

Signed-off-by: Gary Brown <gary@brownuk.com>