### PR TITLE
Polish configuration API

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
@@ -161,7 +161,7 @@ public class Configuration {
   /**
    * The serviceName that the tracer will use
    */
-  private final String serviceName;
+  private String serviceName;
   private SamplerConfiguration samplerConfig;
   private ReporterConfiguration reporterConfig;
   private CodecConfiguration codecConfig;
@@ -284,6 +284,11 @@ public class Configuration {
     this.metricsFactory = metricsFactory;
   }
 
+  public Configuration withServiceName(String serviceName) {
+    this.serviceName = Tracer.Builder.checkValidServiceName(serviceName);
+    return this;
+  }
+
   public Configuration withReporter(ReporterConfiguration reporterConfig) {
     this.reporterConfig = reporterConfig;
     return this;
@@ -306,12 +311,24 @@ public class Configuration {
     return this;
   }
 
+  public String getServiceName() {
+    return serviceName;
+  }
+
   public ReporterConfiguration getReporter() {
     return reporterConfig;
   }
 
   public SamplerConfiguration getSampler() {
     return samplerConfig;
+  }
+
+  public CodecConfiguration getCodec() {
+    return codecConfig;
+  }
+
+  public MetricsFactory getMetricsFactory() {
+    return metricsFactory;
   }
 
   public Map<String, String> getTracerTags() {
@@ -430,6 +447,14 @@ public class Configuration {
   public static class CodecConfiguration {
     private Map<Format<?>, List<Codec<TextMap>>> codecs;
 
+    public CodecConfiguration() {
+    }
+
+    public CodecConfiguration withCodec(Format<?> format, Codec<TextMap> codec) {
+      addCodec(codecs, format, codec);
+      return this;
+    }
+
     private CodecConfiguration(Map<Format<?>, List<Codec<TextMap>>> codecs) {
       this.codecs = codecs;
     }
@@ -459,6 +484,10 @@ public class Configuration {
         }
       }
       return new CodecConfiguration(codecs);
+    }
+
+    public Map<Format<?>, List<Codec<TextMap>>> getCodecs() {
+      return Collections.unmodifiableMap(codecs);
     }
 
     private static void addCodec(Map<Format<?>, List<Codec<TextMap>>> codecs, Format<?> format, Codec<TextMap> codec) {

--- a/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
@@ -223,7 +223,7 @@ public class Configuration {
       samplerConfig = new SamplerConfiguration();
     }
     if (codecConfig == null) {
-      codecConfig = new CodecConfiguration(Collections.<Format<?>, List<Codec<TextMap>>>emptyMap());
+      codecConfig = new CodecConfiguration();
     }
     if (metricsFactory == null) {
       metricsFactory = new NoopMetricsFactory();
@@ -280,8 +280,9 @@ public class Configuration {
   /**
    * @param metricsFactory the MetricsFactory to use on the Tracer to be built
    */
-  public void withMetricsFactory(MetricsFactory metricsFactory) {
+  public Configuration withMetricsFactory(MetricsFactory metricsFactory) {
     this.metricsFactory = metricsFactory;
+    return this;
   }
 
   public Configuration withServiceName(String serviceName) {
@@ -445,15 +446,12 @@ public class Configuration {
    * CodecConfiguration can be used to support additional trace context propagation codec.
    */
   public static class CodecConfiguration {
-    private Map<Format<?>, List<Codec<TextMap>>> codecs;
+    private final Map<Format<?>, List<Codec<TextMap>>> codecs;
 
     public CodecConfiguration() {
+      codecs = new HashMap<Format<?>, List<Codec<TextMap>>>();
     }
 
-    public CodecConfiguration withCodec(Format<?> format, Codec<TextMap> codec) {
-      addCodec(codecs, format, codec);
-      return this;
-    }
 
     private CodecConfiguration(Map<Format<?>, List<Codec<TextMap>>> codecs) {
       this.codecs = codecs;
@@ -484,6 +482,11 @@ public class Configuration {
         }
       }
       return new CodecConfiguration(codecs);
+    }
+
+    public CodecConfiguration withCodec(Format<?> format, Codec<TextMap> codec) {
+      addCodec(codecs, format, codec);
+      return this;
     }
 
     public Map<Format<?>, List<Codec<TextMap>>> getCodecs() {

--- a/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
@@ -333,6 +333,11 @@ public class ConfigurationTest {
     new Configuration(null);
   }
 
+  @Test(expected = RuntimeException.class)
+  public void testEmptyServiceName() {
+    new Configuration("");
+  }
+
   @Test
   public void testOverrideServiceName() {
     System.setProperty(Configuration.JAEGER_SERVICE_NAME, "Test");


### PR DESCRIPTION
Resolves #394 

- [x] there are getters for all configuration properties
- [x] codec configuration can be created programmatically
- [x] allow overriding service name

Configuration can be created programmatically o via env. If it is created via env all properties can be changed programmatically.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>