### PR TITLE
Do not use deprecated APIs internally

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/reporters/RemoteReporter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/reporters/RemoteReporter.java
@@ -16,9 +16,8 @@ package io.jaegertracing.reporters;
 
 import io.jaegertracing.Span;
 import io.jaegertracing.exceptions.SenderException;
+import io.jaegertracing.metrics.InMemoryMetricsFactory;
 import io.jaegertracing.metrics.Metrics;
-import io.jaegertracing.metrics.NullStatsReporter;
-import io.jaegertracing.metrics.StatsFactoryImpl;
 import io.jaegertracing.senders.Sender;
 import io.jaegertracing.senders.UdpSender;
 import java.util.Timer;
@@ -226,7 +225,7 @@ public class RemoteReporter implements Reporter {
         sender = new UdpSender();
       }
       if (metrics == null) {
-        metrics = new Metrics(new StatsFactoryImpl(new NullStatsReporter()));
+        metrics = new Metrics(new InMemoryMetricsFactory());
       }
       return new RemoteReporter(sender, flushInterval, maxQueueSize, DEFAULT_CLOSE_ENQUEUE_TIMEOUT_MILLIS, metrics);
     }

--- a/jaeger-core/src/main/java/io/jaegertracing/samplers/RemoteControlledSampler.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/samplers/RemoteControlledSampler.java
@@ -15,9 +15,8 @@
 package io.jaegertracing.samplers;
 
 import io.jaegertracing.exceptions.SamplingStrategyErrorException;
+import io.jaegertracing.metrics.InMemoryMetricsFactory;
 import io.jaegertracing.metrics.Metrics;
-import io.jaegertracing.metrics.NullStatsReporter;
-import io.jaegertracing.metrics.StatsFactoryImpl;
 import io.jaegertracing.samplers.http.OperationSamplingParameters;
 import io.jaegertracing.samplers.http.ProbabilisticSamplingStrategy;
 import io.jaegertracing.samplers.http.RateLimitingSamplingStrategy;
@@ -228,7 +227,7 @@ public class RemoteControlledSampler implements Sampler {
         initialSampler = new ProbabilisticSampler(0.001);
       }
       if (metrics == null) {
-        metrics = new Metrics(new StatsFactoryImpl(new NullStatsReporter()));
+        metrics = new Metrics(new InMemoryMetricsFactory());
       }
       return new RemoteControlledSampler(this);
     }

--- a/jaeger-core/src/test/java/io/jaegertracing/baggage/BaggageSetterTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/baggage/BaggageSetterTest.java
@@ -53,7 +53,9 @@ public class BaggageSetterTest {
     mgr = mock(DefaultBaggageRestrictionManager.class);
     setter = new BaggageSetter(mgr, metrics);
     tracer =
-        new Tracer.Builder(SERVICE, reporter, new ConstSampler(true))
+        new Tracer.Builder(SERVICE)
+            .withReporter(reporter)
+            .withSampler(new ConstSampler(true))
             .withMetrics(metrics)
             .build();
     span = (Span) tracer.buildSpan("some-operation").startManual();
@@ -103,7 +105,9 @@ public class BaggageSetterTest {
   @Test
   public void testUnsampledSpan() {
     tracer =
-        new Tracer.Builder("SamplerTest", reporter, new ConstSampler(false))
+        new Tracer.Builder(SERVICE)
+            .withReporter(reporter)
+            .withSampler(new ConstSampler(false))
             .withMetrics(metrics)
             .build();
     span = (Span) tracer.buildSpan("some-operation").startManual();

--- a/jaeger-core/src/test/java/io/jaegertracing/reporters/RemoteReporterTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/reporters/RemoteReporterTest.java
@@ -210,7 +210,12 @@ public class RemoteReporterTest {
   @Test
   public void testFlushUpdatesQueueLength() throws Exception {
     int neverFlushInterval = Integer.MAX_VALUE;
-    reporter = new RemoteReporter(sender, neverFlushInterval, maxQueueSize, metrics);
+    reporter = new RemoteReporter.Builder()
+        .withSender(sender)
+        .withFlushInterval(neverFlushInterval)
+        .withMaxQueueSize(maxQueueSize)
+        .withMetrics(metrics)
+        .build();
     tracer = new Tracer.Builder("test-remote-reporter", reporter, new ConstSampler(true))
         .withMetrics(metrics)
         .build();
@@ -242,7 +247,12 @@ public class RemoteReporterTest {
       }
     };
 
-    reporter = new RemoteReporter(sender, flushInterval, maxQueueSize, metrics);
+    reporter = new RemoteReporter.Builder()
+        .withSender(sender)
+        .withFlushInterval(flushInterval)
+        .withMaxQueueSize(maxQueueSize)
+        .withMetrics(metrics)
+        .build();
     tracer =
           new Tracer.Builder("test-remote-reporter", reporter, new ConstSampler(true))
                 .withMetrics(metrics)

--- a/jaeger-core/src/test/java/io/jaegertracing/senders/HttpSenderTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/senders/HttpSenderTest.java
@@ -63,9 +63,10 @@ public class HttpSenderTest extends JerseyTest {
   public void sendHappy() throws Exception {
     new HttpSender(target("/api/traces").getUri().toString())
         .send(new Process("robotrock"), generateSpans());
-    new HttpSender(target("/api/traces").getUri().toString(), 6500)
+    new HttpSender.Builder(target("/api/traces").getUri().toString()).withMaxPacketSize(6500).build()
         .send(new Process("name"), generateSpans());
-    new HttpSender(target("/api/traces").getUri().toString(), 6500, new OkHttpClient())
+    new HttpSender.Builder(target("/api/traces").getUri().toString()).withMaxPacketSize(6500)
+          .withClient(new OkHttpClient()).build()
         .send(new Process("name"), generateSpans());
   }
 

--- a/jaeger-core/src/test/java/io/jaegertracing/senders/UdpSenderTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/senders/UdpSenderTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 import io.jaegertracing.Span;
 import io.jaegertracing.Tracer;
 import io.jaegertracing.exceptions.SenderException;
-import io.jaegertracing.metrics.InMemoryStatsReporter;
+import io.jaegertracing.metrics.InMemoryMetricsFactory;
 import io.jaegertracing.reporters.InMemoryReporter;
 import io.jaegertracing.reporters.Reporter;
 import io.jaegertracing.reporters.protocols.JaegerThriftSpanConverter;
@@ -68,7 +68,7 @@ public class UdpSenderTest {
     reporter = new InMemoryReporter();
     tracer =
         new Tracer.Builder(SERVICE_NAME, reporter, new ConstSampler(true))
-            .withStatsReporter(new InMemoryStatsReporter())
+            .withMetricsFactory(new InMemoryMetricsFactory())
             .withTag("foo", "bar")
             .build();
     sender = new UdpSender(destHost, destPort, maxPacketSize);

--- a/jaeger-zipkin/src/test/java/io/jaegertracing/senders/zipkin/ZipkinSenderTest.java
+++ b/jaeger-zipkin/src/test/java/io/jaegertracing/senders/zipkin/ZipkinSenderTest.java
@@ -21,7 +21,7 @@ import io.jaegertracing.Span;
 import io.jaegertracing.SpanContext;
 import io.jaegertracing.Tracer;
 import io.jaegertracing.exceptions.SenderException;
-import io.jaegertracing.metrics.InMemoryStatsReporter;
+import io.jaegertracing.metrics.InMemoryMetricsFactory;
 import io.jaegertracing.reporters.InMemoryReporter;
 import io.jaegertracing.reporters.Reporter;
 import io.jaegertracing.samplers.ConstSampler;
@@ -56,7 +56,7 @@ public class ZipkinSenderTest {
     reporter = new InMemoryReporter();
     tracer =
         new Tracer.Builder("test-sender", reporter, new ConstSampler(true))
-            .withStatsReporter(new InMemoryStatsReporter())
+            .withMetricsFactory(new InMemoryMetricsFactory())
             .build();
     sender = newSender(messageMaxBytes);
     converter = new ThriftSpanConverter();


### PR DESCRIPTION
This is not a breaking change! It does not introduces/removes any APIs or implementation. It only removes calls to deprecated APIs from internal packages.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>