### PR TITLE
Do not use deprecated Tracer.Builder constructor internally

### DIFF
--- a/jaeger-core/src/test/java/io/jaegertracing/PropagationTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/PropagationTest.java
@@ -34,8 +34,10 @@ import org.junit.Test;
 public class PropagationTest {
   @Test
   public void testDebugCorrelationId() {
-    Tracer tracer =
-        new Tracer.Builder("test", new InMemoryReporter(), new ConstSampler(true)).build();
+    Tracer tracer = new Tracer.Builder("test")
+            .withReporter(new InMemoryReporter())
+            .withSampler(new ConstSampler(true))
+            .build();
     Map<String, String> headers = new HashMap<>();
     headers.put(Constants.DEBUG_ID_HEADER_KEY, "Coraline");
     TextMap carrier = new TextMapExtractAdapter(headers);
@@ -51,8 +53,10 @@ public class PropagationTest {
 
   @Test
   public void testActiveSpanPropagation() {
-    Tracer tracer =
-        new Tracer.Builder("test", new InMemoryReporter(), new ConstSampler(true)).build();
+    Tracer tracer = new Tracer.Builder("test")
+            .withReporter(new InMemoryReporter())
+            .withSampler(new ConstSampler(true))
+            .build();
     try (Scope parent = tracer.buildSpan("parent").startActive(true)) {
       assertEquals(parent, tracer.scopeManager().active());
     }
@@ -61,8 +65,10 @@ public class PropagationTest {
   @Test
   public void testActiveSpanAutoReference() {
     InMemoryReporter reporter = new InMemoryReporter();
-    Tracer tracer =
-        new Tracer.Builder("test", reporter, new ConstSampler(true)).build();
+    Tracer tracer = new Tracer.Builder("test")
+            .withReporter(reporter)
+            .withSampler(new ConstSampler(true))
+            .build();
     try (Scope parent = tracer.buildSpan("parent").startActive(true)) {
       tracer.buildSpan("child").startActive(true).close();
     }
@@ -85,8 +91,10 @@ public class PropagationTest {
   @Test
   public void testActiveSpanAutoFinishOnClose() {
     InMemoryReporter reporter = new InMemoryReporter();
-    Tracer tracer =
-        new Tracer.Builder("test", reporter, new ConstSampler(true)).build();
+    Tracer tracer = new Tracer.Builder("test")
+            .withReporter(reporter)
+            .withSampler(new ConstSampler(true))
+            .build();
     tracer.buildSpan("parent").startActive(true).close();
     assertEquals(1, reporter.getSpans().size());
   }
@@ -94,8 +102,10 @@ public class PropagationTest {
   @Test
   public void testActiveSpanNotAutoFinishOnClose() {
     InMemoryReporter reporter = new InMemoryReporter();
-    Tracer tracer =
-        new Tracer.Builder("test", reporter, new ConstSampler(true)).build();
+    Tracer tracer = new Tracer.Builder("test")
+            .withReporter(reporter)
+            .withSampler(new ConstSampler(true))
+            .build();
     Scope scope = tracer.buildSpan("parent").startActive(false);
     Span span = (Span) scope.span();
     scope.close();
@@ -107,8 +117,10 @@ public class PropagationTest {
   @Test
   public void testIgnoreActiveSpan() {
     InMemoryReporter reporter = new InMemoryReporter();
-    Tracer tracer =
-        new Tracer.Builder("test", reporter, new ConstSampler(true)).build();
+    Tracer tracer = new Tracer.Builder("test")
+            .withReporter(reporter)
+            .withSampler(new ConstSampler(true))
+            .build();
     try (Scope parent = tracer.buildSpan("parent").startActive(true)) {
       tracer.buildSpan("child").ignoreActiveSpan().startActive(true).close();
     }
@@ -126,8 +138,10 @@ public class PropagationTest {
   @Test
   public void testNoAutoRefWithExistingRefs() {
     InMemoryReporter reporter = new InMemoryReporter();
-    Tracer tracer =
-        new Tracer.Builder("test", reporter, new ConstSampler(true)).build();
+    Tracer tracer = new Tracer.Builder("test")
+            .withReporter(reporter)
+            .withSampler(new ConstSampler(true))
+            .build();
 
     io.opentracing.Span initialSpan = tracer.buildSpan("initial").start();
 
@@ -156,8 +170,9 @@ public class PropagationTest {
   @Test
   public void testCustomScopeManager() {
     Scope scope = mock(Scope.class);
-    Tracer tracer =
-        new Tracer.Builder("test", new InMemoryReporter(), new ConstSampler(true))
+    Tracer tracer = new Tracer.Builder("test")
+        .withReporter(new InMemoryReporter())
+        .withSampler(new ConstSampler(true))
         .withScopeManager(new ScopeManager() {
 
           @Override

--- a/jaeger-core/src/test/java/io/jaegertracing/SpanTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/SpanTest.java
@@ -58,8 +58,9 @@ public class SpanTest {
     reporter = new InMemoryReporter();
     clock = mock(Clock.class);
     metrics = new Metrics(metricsFactory);
-    tracer =
-        new Tracer.Builder("SamplerTest", reporter, new ConstSampler(true))
+    tracer = new Tracer.Builder("SamplerTest")
+            .withReporter(reporter)
+            .withSampler(new ConstSampler(true))
             .withMetrics(metrics)
             .withClock(clock)
             .withBaggageRestrictionManager(new DefaultBaggageRestrictionManager())
@@ -78,8 +79,9 @@ public class SpanTest {
   public void testSetAndGetBaggageItem() {
     final String service = "SamplerTest";
     final BaggageRestrictionManager mgr = Mockito.mock(DefaultBaggageRestrictionManager.class);
-    tracer =
-        new Tracer.Builder(service, reporter, new ConstSampler(true))
+    tracer = new Tracer.Builder(service)
+            .withReporter(reporter)
+            .withSampler(new ConstSampler(true))
             .withClock(clock)
             .withBaggageRestrictionManager(mgr)
             .build();
@@ -410,7 +412,9 @@ public class SpanTest {
 
   @Test
   public void testNoExpandExceptionLogs() {
-    Tracer tracer = new Tracer.Builder("fo", reporter, new ConstSampler(true))
+    Tracer tracer = new Tracer.Builder("fo")
+        .withReporter(reporter)
+        .withSampler(new ConstSampler(true))
         .build();
 
     Span span = (Span)tracer.buildSpan("foo").start();
@@ -428,7 +432,9 @@ public class SpanTest {
 
   @Test
   public void testSpanNotSampled() {
-    Tracer tracer = new Tracer.Builder("fo", reporter, new ConstSampler(false))
+    Tracer tracer = new Tracer.Builder("fo")
+        .withReporter(reporter)
+        .withSampler(new ConstSampler(false))
         .build();
     io.opentracing.Span foo = tracer.buildSpan("foo")
         .start();

--- a/jaeger-core/src/test/java/io/jaegertracing/TracerTagsTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/TracerTagsTest.java
@@ -28,7 +28,9 @@ public class TracerTagsTest {
   @Test
   public void testTracerTags() throws Exception {
     InMemoryReporter spanReporter = new InMemoryReporter();
-    Tracer tracer = new Tracer.Builder("x", spanReporter, new ConstSampler(true))
+    Tracer tracer = new Tracer.Builder("x")
+        .withReporter(spanReporter)
+        .withSampler(new ConstSampler(true))
         .withZipkinSharedRpcSpan()
         .withTag("tracer.tag.str", "y")
         .build();

--- a/jaeger-core/src/test/java/io/jaegertracing/TracerTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/TracerTest.java
@@ -85,8 +85,9 @@ public class TracerTest {
     @SuppressWarnings("unchecked")
     Injector<TextMap> injector = mock(Injector.class);
 
-    Tracer tracer =
-        new Tracer.Builder("TracerTestService", new InMemoryReporter(), new ConstSampler(true))
+    Tracer tracer = new Tracer.Builder("TracerTestService")
+            .withReporter(new InMemoryReporter())
+            .withSampler(new ConstSampler(true))
             .withMetrics(new Metrics(new InMemoryMetricsFactory()))
             .registerInjector(Format.Builtin.TEXT_MAP, injector)
             .build();
@@ -100,12 +101,12 @@ public class TracerTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testServiceNameNotNull() {
-    new Tracer.Builder(null, new InMemoryReporter(), new ConstSampler(true));
+    new Tracer.Builder(null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testServiceNameNotEmptyNull() {
-    new Tracer.Builder("  ", new InMemoryReporter(), new ConstSampler(true));
+    new Tracer.Builder("  ");
   }
 
   @Test
@@ -126,8 +127,9 @@ public class TracerTest {
 
   @Test
   public void testWithBaggageRestrictionManager() {
-    tracer =
-        new Tracer.Builder("TracerTestService", new InMemoryReporter(), new ConstSampler(true))
+    tracer = new Tracer.Builder("TracerTestService")
+            .withReporter(new InMemoryReporter())
+            .withSampler(new ConstSampler(true))
             .withMetrics(new Metrics(metricsFactory))
             .build();
     Span span = (Span) tracer.buildSpan("some-operation").start();
@@ -146,7 +148,10 @@ public class TracerTest {
   public void testClose() {
     Reporter reporter = mock(Reporter.class);
     Sampler sampler = mock(Sampler.class);
-    tracer = new Tracer.Builder("bonda", reporter, sampler).build();
+    tracer = new Tracer.Builder("bonda")
+        .withReporter(reporter)
+        .withSampler(sampler)
+        .build();
     tracer.close();
     verify(reporter).close();
     verify(sampler).close();
@@ -154,7 +159,10 @@ public class TracerTest {
 
   @Test
   public void testAsChildOfAcceptNull() {
-    tracer = new Tracer.Builder("foo", new InMemoryReporter(), new ConstSampler(true)).build();
+    tracer = new Tracer.Builder("foo")
+        .withReporter(new InMemoryReporter())
+        .withSampler(new ConstSampler(true))
+        .build();
 
     Span span = (Span)tracer.buildSpan("foo").asChildOf((Span) null).start();
     span.finish();

--- a/jaeger-core/src/test/java/io/jaegertracing/metrics/InMemoryMetricsFactoryTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/metrics/InMemoryMetricsFactoryTest.java
@@ -100,8 +100,9 @@ public class InMemoryMetricsFactoryTest {
   @Test
   public void emptyValueForTag() {
     InMemoryMetricsFactory metricsFactory = new InMemoryMetricsFactory();
-    Tracer tracer =
-        new Tracer.Builder("metricsFactoryTest", new InMemoryReporter(), new ConstSampler(true))
+    Tracer tracer =  new Tracer.Builder("metricsFactoryTest")
+            .withReporter(new InMemoryReporter())
+            .withSampler(new ConstSampler(true))
             .withMetrics(new Metrics(metricsFactory))
             .build();
 
@@ -113,8 +114,9 @@ public class InMemoryMetricsFactoryTest {
   @Test
   public void canBeUsedWithMetrics() {
     InMemoryMetricsFactory metricsFactory = new InMemoryMetricsFactory();
-    Tracer tracer =
-        new Tracer.Builder("metricsFactoryTest", new InMemoryReporter(), new ConstSampler(true))
+    Tracer tracer = new Tracer.Builder("metricsFactoryTest")
+            .withReporter(new InMemoryReporter())
+            .withSampler(new ConstSampler(true))
             .withMetrics(new Metrics(metricsFactory))
             .build();
 

--- a/jaeger-core/src/test/java/io/jaegertracing/metrics/NoopMetricsFactoryTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/metrics/NoopMetricsFactoryTest.java
@@ -88,8 +88,9 @@ public class NoopMetricsFactoryTest {
   @Test
   public void canBeUsedWithMetrics() {
     NoopMetricsFactory metricsFactory = new NoopMetricsFactory();
-    Tracer tracer =
-        new Tracer.Builder("metricsFactoryTest", new InMemoryReporter(), new ConstSampler(true))
+    Tracer tracer = new Tracer.Builder("metricsFactoryTest")
+            .withReporter(new InMemoryReporter())
+            .withSampler(new ConstSampler(true))
             .withMetrics(new Metrics(metricsFactory))
             .build();
 

--- a/jaeger-core/src/test/java/io/jaegertracing/reporters/RemoteReporterTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/reporters/RemoteReporterTest.java
@@ -60,8 +60,9 @@ public class RemoteReporterTest {
         .withMaxQueueSize(maxQueueSize)
         .withMetrics(metrics)
         .build();
-    tracer =
-        new Tracer.Builder("test-remote-reporter", reporter, new ConstSampler(true))
+    tracer = new Tracer.Builder("test-remote-reporter")
+            .withReporter(reporter)
+            .withSampler(new ConstSampler(true))
             .withMetrics(metrics)
             .build();
   }
@@ -176,7 +177,9 @@ public class RemoteReporterTest {
   public void testCloseWhenQueueFull() {
     int closeTimeoutMillis = 5;
     reporter = new RemoteReporter(sender, Integer.MAX_VALUE, maxQueueSize, closeTimeoutMillis, metrics);
-    tracer = new Tracer.Builder("test-remote-reporter", reporter, new ConstSampler(true))
+    tracer = new Tracer.Builder("test-remote-reporter")
+        .withReporter(reporter)
+        .withSampler(new ConstSampler(true))
         .withMetrics(metrics)
         .build();
     // change sender to blocking mode
@@ -216,7 +219,9 @@ public class RemoteReporterTest {
         .withMaxQueueSize(maxQueueSize)
         .withMetrics(metrics)
         .build();
-    tracer = new Tracer.Builder("test-remote-reporter", reporter, new ConstSampler(true))
+    tracer = new Tracer.Builder("test-remote-reporter")
+        .withReporter(reporter)
+        .withSampler(new ConstSampler(true))
         .withMetrics(metrics)
         .build();
 
@@ -253,10 +258,11 @@ public class RemoteReporterTest {
         .withMaxQueueSize(maxQueueSize)
         .withMetrics(metrics)
         .build();
-    tracer =
-          new Tracer.Builder("test-remote-reporter", reporter, new ConstSampler(true))
-                .withMetrics(metrics)
-                .build();
+    tracer = new Tracer.Builder("test-remote-reporter")
+              .withReporter(reporter)
+              .withSampler(new ConstSampler(true))
+              .withMetrics(metrics)
+              .build();
 
     tracer.buildSpan("mySpan").start().finish();
     latch.await(1, TimeUnit.SECONDS);

--- a/jaeger-core/src/test/java/io/jaegertracing/reporters/protocols/JaegerThriftSpanConverterTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/reporters/protocols/JaegerThriftSpanConverterTest.java
@@ -46,8 +46,9 @@ public class JaegerThriftSpanConverterTest {
 
   @Before
   public void setUp() {
-    tracer =
-        new Tracer.Builder("test-service-name", new InMemoryReporter(), new ConstSampler(true))
+    tracer = new Tracer.Builder("test-service-name")
+            .withReporter(new InMemoryReporter())
+            .withSampler(new ConstSampler(true))
             .build();
   }
 

--- a/jaeger-core/src/test/java/io/jaegertracing/senders/UdpSenderTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/senders/UdpSenderTest.java
@@ -67,7 +67,9 @@ public class UdpSenderTest {
     server = startServer();
     reporter = new InMemoryReporter();
     tracer =
-        new Tracer.Builder(SERVICE_NAME, reporter, new ConstSampler(true))
+        new Tracer.Builder(SERVICE_NAME)
+            .withReporter(reporter)
+            .withSampler(new ConstSampler(true))
             .withMetricsFactory(new InMemoryMetricsFactory())
             .withTag("foo", "bar")
             .build();

--- a/jaeger-zipkin/src/test/java/io/jaegertracing/senders/zipkin/ThriftSpanConverterTest.java
+++ b/jaeger-zipkin/src/test/java/io/jaegertracing/senders/zipkin/ThriftSpanConverterTest.java
@@ -51,9 +51,10 @@ public class ThriftSpanConverterTest {
 
   @Before
   public void setUp() {
-    tracer =
-        new Tracer.Builder("test-service-name", new InMemoryReporter(), new ConstSampler(true))
-                .withZipkinSharedRpcSpan()
+    tracer = new Tracer.Builder("test-service-name")
+            .withReporter(new InMemoryReporter())
+            .withSampler(new ConstSampler(true))
+            .withZipkinSharedRpcSpan()
             .build();
   }
 
@@ -71,7 +72,10 @@ public class ThriftSpanConverterTest {
 
   @DataProvider
   public static Object[][] dataProviderTracerTags() {
-    Tracer tracer = new Tracer.Builder("x", null, null).build();
+    Tracer tracer = new Tracer.Builder("x")
+        .withReporter(null)
+        .withSampler(null)
+        .build();
 
     Map<String, String> rootTags = new HashMap<>();
     rootTags.put("tracer.jaeger.version", tracer.getVersion());
@@ -111,7 +115,9 @@ public class ThriftSpanConverterTest {
   @UseDataProvider("dataProviderTracerTags")
   public void testTracerTags(SpanType spanType, Map<String, String> expectedTags) throws Exception {
     InMemoryReporter spanReporter = new InMemoryReporter();
-    Tracer tracer = new Tracer.Builder("x", spanReporter, new ConstSampler(true))
+    Tracer tracer = new Tracer.Builder("x")
+        .withReporter(spanReporter)
+        .withSampler(new ConstSampler(true))
         .withZipkinSharedRpcSpan()
         .withTag("tag.str", "y")
         .withTag("tag.bool", true)

--- a/jaeger-zipkin/src/test/java/io/jaegertracing/senders/zipkin/ZipkinSenderTest.java
+++ b/jaeger-zipkin/src/test/java/io/jaegertracing/senders/zipkin/ZipkinSenderTest.java
@@ -54,8 +54,9 @@ public class ZipkinSenderTest {
   @Before
   public void setUp() throws Exception {
     reporter = new InMemoryReporter();
-    tracer =
-        new Tracer.Builder("test-sender", reporter, new ConstSampler(true))
+    tracer = new Tracer.Builder("test-sender")
+            .withReporter(reporter)
+            .withSampler(new ConstSampler(true))
             .withMetricsFactory(new InMemoryMetricsFactory())
             .build();
     sender = newSender(messageMaxBytes);


### PR DESCRIPTION
Related to #413 and  #395 

This does not change any APIs or implementation. The change is only in test classes - removed invocation of deprecated `Tracer.Builder(name, reporter, sampler)`

Signed-off-by: Pavol Loffay <ploffay@redhat.com>