### PR TITLE
fix deploy stage on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 stages:
   - name: test
   - name: deploy
-    if: env(TRAVIS_PULL_REQUEST) = false
+    if: NOT (type IN (pull_request))
 
 jobs:
   include:


### PR DESCRIPTION
https://github.com/jaegertracing/jaeger-client-java/pull/389 changed travis configuration to use stages. There is a condition which enables `deploy` stage https://github.com/jaegertracing/jaeger-client-java/pull/389/files#diff-354f30a63fb0907d4ad57269548329e3R36. However it doesn't seem to work  see https://travis-ci.org/jaegertracing/jaeger-client-java/builds/379736616 `deploy` is missing

Signed-off-by: Pavol Loffay <ploffay@redhat.com>