### PR TITLE
Use string builder instead of string format

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/SpanContext.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/SpanContext.java
@@ -92,8 +92,12 @@ public class SpanContext implements io.opentracing.SpanContext {
   }
 
   public String contextAsString() {
-    // TODO(oibe) profile, and make sure this is fast enough
-    return String.format("%x:%x:%x:%x", traceId, spanId, parentId, flags);
+    return new StringBuilder()
+        .append(Long.toHexString(traceId)).append(":")
+        .append(Long.toHexString(spanId)).append(":")
+        .append(Long.toHexString(parentId)).append(":")
+        .append(Integer.toHexString(flags & 0xFF))
+        .toString();
   }
 
   @Override

--- a/jaeger-core/src/main/java/io/jaegertracing/SpanContext.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/SpanContext.java
@@ -92,11 +92,12 @@ public class SpanContext implements io.opentracing.SpanContext {
   }
 
   public String contextAsString() {
+    int intFlag = flags & 0xFF;
     return new StringBuilder()
         .append(Long.toHexString(traceId)).append(":")
         .append(Long.toHexString(spanId)).append(":")
         .append(Long.toHexString(parentId)).append(":")
-        .append(Integer.toHexString(flags & 0xFF))
+        .append(Integer.toHexString(intFlag))
         .toString();
   }
 


### PR DESCRIPTION
Improve performance by using `StringBuilder` instead of `String.format` see https://stackoverflow.com/a/1281651/4158442

There are more usages of `String.format` but only this one is used often.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>