### PR TITLE
Fix xdock image build on travis

### DIFF
--- a/travis/publish-crossdock.sh
+++ b/travis/publish-crossdock.sh
@@ -14,6 +14,7 @@ docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
 
 set -x
 
+./gradlew shadowJar
 pushd 'jaeger-crossdock'
 docker build -f Dockerfile -t $REPO:$COMMIT .
 popd


### PR DESCRIPTION
All travis builds on master fail on 

https://travis-ci.org/jaegertracing/jaeger-client-java/jobs/382664568#L729

>ADD failed: stat /var/lib/docker/tmp/docker-builder911182134/build/libs/jaeger-crossdock.jar: no such file or directory

Signed-off-by: Pavol Loffay <ploffay@redhat.com>