### PR TITLE
Deprecate B3 codec contructor

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/propagation/B3TextMapCodec.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/propagation/B3TextMapCodec.java
@@ -57,6 +57,10 @@ public class B3TextMapCodec implements Codec<TextMap> {
   private static final PrefixedKeys keys = new PrefixedKeys();
   private final String baggagePrefix;
 
+  /**
+   * @deprecated use {@link Builder} instead
+   */
+  @Deprecated
   public B3TextMapCodec() {
     this(new Builder());
   }


### PR DESCRIPTION
https://github.com/jaegertracing/jaeger-client-java/pull/438 introduced a builder in B3 codec which results in some inconsistency. The codec can be created via constructor and builder. We should either deprecate constructor or remove builder in favor of additional constructor. 

I don't expect a lot of parameters in this codec, maybe url encoding, maybe someting more.

* Be consistent and use only builder pattern

Signed-off-by: Pavol Loffay <ploffay@redhat.com>