### PR TITLE
Fix travis release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
 
     - stage: deploy
       env: [ NAME=deploy-to-maven ]
-      script: ./gradlew upload
+      script: travis_wait 70 ./gradlew upload
 
     - stage: deploy
       env: [ NAME=deploy-crossdock-to-dockerhub ]

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.17.0'
 }
 
-ext.developmentVersion = getProperty('developmentVersion','0.29.0')
+ext.developmentVersion = getProperty('developmentVersion','0.29.1')
 
 ext.opentracingVersion = getProperty('opentracingVersion','0.31.0')
 ext.guavaVersion = getProperty('guavaVersion','18.0')
@@ -87,6 +87,7 @@ subprojects {
             // Dealing with error "Wrong number of received repositories in state 'open'" (http://bit.ly/2ybracm)
             numberOfRetries = 50
             delayBetweenRetriesInMillis = 3000
+            stagingProfileId = project.version.replaceAll("\\.", "")
         }
 
         uploadArchives.finalizedBy closeAndReleaseRepository


### PR DESCRIPTION
This could be the solution for #390 - see the last comment. The upload took 50 minutes on my machine, therefore `travis_wait`.

The only way how to verify is to actually trigger the build

Signed-off-by: Pavol Loffay <ploffay@redhat.com>