### PR TITLE
HttpSender errors are not logged #406

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/senders/HttpSender.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/senders/HttpSender.java
@@ -21,6 +21,7 @@ import io.jaegertracing.thriftjava.Span;
 import java.io.IOException;
 import java.util.List;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 import okhttp3.Credentials;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
@@ -31,6 +32,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 
 @ToString(exclude = {"httpClient", "requestBuilder"})
+@Slf4j
 public class HttpSender extends ThriftSender {
   private static final String HTTP_COLLECTOR_JAEGER_THRIFT_FORMAT_PARAM = "format=jaeger.thrift";
   private static final int ONE_MB_IN_BYTES = 1048576;
@@ -74,6 +76,8 @@ public class HttpSender extends ThriftSender {
         responseBody = response.body() != null ? response.body().string() : "null";
       } catch (IOException e) {
         responseBody = "unable to read response";
+
+        log.error("Unable to read response. Error: ", e);
       }
 
       String exceptionMessage = String.format("Could not send %d spans, response %d: %s",


### PR DESCRIPTION
Signed-off-by: chandresh-pancholi <chandreshpancholi007@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- HttpSender errors are not logged #406 

## Short description of the changes
- Adding error log when the response  is not successful and can not read it
