### PR TITLE
HttpSender errors are not logged #406

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/reporters/RemoteReporter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/reporters/RemoteReporter.java
@@ -169,6 +169,8 @@ public class RemoteReporter implements Reporter {
           try {
             command.execute();
           } catch (SenderException e) {
+            log.error("Sender exception error: ", e);
+            
             metrics.reporterFailure.inc(e.getDroppedSpanCount());
           }
         } catch (InterruptedException e) {

--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/senders/HttpSender.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/senders/HttpSender.java
@@ -75,9 +75,9 @@ public class HttpSender extends ThriftSender {
       try {
         responseBody = response.body() != null ? response.body().string() : "null";
       } catch (IOException e) {
-          responseBody = String.format("Unable to read response: %s", e.getMessage());
+        responseBody = String.format("Unable to read response: %s", e.getMessage());
 
-          log.error(responseBody, e);
+        log.error(responseBody, e);
       }
 
       String exceptionMessage = String.format("Could not send %d spans, response %d: %s",

--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/senders/HttpSender.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/senders/HttpSender.java
@@ -32,7 +32,6 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 
 @ToString(exclude = {"httpClient", "requestBuilder"})
-@Slf4j
 public class HttpSender extends ThriftSender {
   private static final String HTTP_COLLECTOR_JAEGER_THRIFT_FORMAT_PARAM = "format=jaeger.thrift";
   private static final int ONE_MB_IN_BYTES = 1048576;
@@ -76,8 +75,6 @@ public class HttpSender extends ThriftSender {
         responseBody = response.body() != null ? response.body().string() : "null";
       } catch (IOException e) {
         responseBody = String.format("Unable to read response: %s", e.getMessage());
-
-        log.error(responseBody, e);
       }
 
       String exceptionMessage = String.format("Could not send %d spans, response %d: %s",

--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/senders/HttpSender.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/senders/HttpSender.java
@@ -21,6 +21,7 @@ import io.jaegertracing.thriftjava.Span;
 import java.io.IOException;
 import java.util.List;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 import okhttp3.Credentials;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
@@ -31,6 +32,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 
 @ToString(exclude = {"httpClient", "requestBuilder"})
+@Slf4j
 public class HttpSender extends ThriftSender {
   private static final String HTTP_COLLECTOR_JAEGER_THRIFT_FORMAT_PARAM = "format=jaeger.thrift";
   private static final int ONE_MB_IN_BYTES = 1048576;
@@ -73,7 +75,9 @@ public class HttpSender extends ThriftSender {
       try {
         responseBody = response.body() != null ? response.body().string() : "null";
       } catch (IOException e) {
-        responseBody = "unable to read response";
+          responseBody = String.format("Unable to read response: %s", e.getMessage());
+
+          log.error(responseBody, e);
       }
 
       String exceptionMessage = String.format("Could not send %d spans, response %d: %s",


### PR DESCRIPTION
Signed-off-by: chandresh-pancholi<chandreshpancholi007@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- #406 

## Short description of the changes
- Logging errors when the response is not successful and not able to read response body event though it is not null
