### PR TITLE
Rename 'io.jaegertracing.Span' to 'io.jaegertracing.JaegerSpan'

### DIFF
--- a/jaeger-core/README.md
+++ b/jaeger-core/README.md
@@ -19,7 +19,7 @@ sending data to a backend, like [`io.jaegertracing:jaeger-thrift`](../jaeger-thr
 
 ### Production
 
-Tracer can be created via `io.jaegertracing.Tracer.Builder` or `io.jaegertracing.Configuration`.
+Tracer can be created via `io.jaegertracing.JaegerTracer.Builder` or `io.jaegertracing.Configuration`.
 For production it is recommended to use both classes with default values.
 
 `Tracer.Builder` example:

--- a/jaeger-core/src/main/java/io/jaegertracing/JaegerSpanContext.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/JaegerSpanContext.java
@@ -16,12 +16,13 @@ package io.jaegertracing;
 
 import io.jaegertracing.exceptions.EmptyTracerStateStringException;
 import io.jaegertracing.exceptions.MalformedTracerStateStringException;
+import io.opentracing.SpanContext;
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-public class SpanContext implements io.opentracing.SpanContext {
+public class JaegerSpanContext implements SpanContext {
   protected static final byte flagSampled = 1;
   protected static final byte flagDebug = 2;
 
@@ -32,11 +33,11 @@ public class SpanContext implements io.opentracing.SpanContext {
   private final Map<String, String> baggage;
   private final String debugId;
 
-  public SpanContext(long traceId, long spanId, long parentId, byte flags) {
+  public JaegerSpanContext(long traceId, long spanId, long parentId, byte flags) {
     this(traceId, spanId, parentId, flags, Collections.<String, String>emptyMap(), null);
   }
 
-  SpanContext(
+  JaegerSpanContext(
       long traceId,
       long spanId,
       long parentId,
@@ -106,7 +107,7 @@ public class SpanContext implements io.opentracing.SpanContext {
     return contextAsString();
   }
 
-  public static SpanContext contextFromString(String value)
+  public static JaegerSpanContext contextFromString(String value)
       throws MalformedTracerStateStringException, EmptyTracerStateStringException {
     if (value == null || value.equals("")) {
       throw new EmptyTracerStateStringException();
@@ -121,29 +122,29 @@ public class SpanContext implements io.opentracing.SpanContext {
       TODO(oibe) because java doesn't like to convert large hex strings to longs
       we should write this manually instead of using BigInteger.
     */
-    return new SpanContext(
+    return new JaegerSpanContext(
         new BigInteger(parts[0], 16).longValue(),
         new BigInteger(parts[1], 16).longValue(),
         new BigInteger(parts[2], 16).longValue(),
         new BigInteger(parts[3], 16).byteValue());
   }
 
-  public SpanContext withBaggageItem(String key, String val) {
+  public JaegerSpanContext withBaggageItem(String key, String val) {
     Map<String, String> newBaggage = new HashMap<String, String>(this.baggage);
     if (val == null) {
       newBaggage.remove(key);
     } else {
       newBaggage.put(key, val);
     }
-    return new SpanContext(traceId, spanId, parentId, flags, newBaggage, debugId);
+    return new JaegerSpanContext(traceId, spanId, parentId, flags, newBaggage, debugId);
   }
 
-  public SpanContext withBaggage(Map<String, String> newBaggage) {
-    return new SpanContext(traceId, spanId, parentId, flags, newBaggage, debugId);
+  public JaegerSpanContext withBaggage(Map<String, String> newBaggage) {
+    return new JaegerSpanContext(traceId, spanId, parentId, flags, newBaggage, debugId);
   }
 
-  public SpanContext withFlags(byte flags) {
-    return new SpanContext(traceId, spanId, parentId, flags, baggage, debugId);
+  public JaegerSpanContext withFlags(byte flags) {
+    return new JaegerSpanContext(traceId, spanId, parentId, flags, baggage, debugId);
   }
 
   /**
@@ -160,19 +161,19 @@ public class SpanContext implements io.opentracing.SpanContext {
   }
 
   /**
-   * Create a new dummy SpanContext as a container for debugId string. This is used when
+   * Create a new dummy JaegerSpanContext as a container for debugId string. This is used when
    * "jaeger-debug-id" header is passed in the request headers and forces the trace to be sampled as
    * debug trace, and the value of header recorded as a span tag to serve as a searchable
    * correlation ID.
    *
    * @param debugId arbitrary string used as correlation ID
    *
-   * @return new dummy SpanContext that serves as a container for debugId only.
+   * @return new dummy JaegerSpanContext that serves as a container for debugId only.
    *
    * @see Constants#DEBUG_ID_HEADER_KEY
    */
-  public static SpanContext withDebugId(String debugId) {
-    return new SpanContext(0, 0, 0, (byte) 0, Collections.<String, String>emptyMap(), debugId);
+  public static JaegerSpanContext withDebugId(String debugId) {
+    return new JaegerSpanContext(0, 0, 0, (byte) 0, Collections.<String, String>emptyMap(), debugId);
   }
 
   String getDebugId() {

--- a/jaeger-core/src/main/java/io/jaegertracing/PropagationRegistry.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/PropagationRegistry.java
@@ -52,7 +52,7 @@ class PropagationRegistry {
     private final Extractor<T> decorated;
 
     @Override
-    public SpanContext extract(T carrier) {
+    public JaegerSpanContext extract(T carrier) {
       try {
         return decorated.extract(carrier);
       } catch (RuntimeException ex) {
@@ -70,7 +70,7 @@ class PropagationRegistry {
     private final Injector<T> decorated;
 
     @Override
-    public void inject(SpanContext spanContext, T carrier) {
+    public void inject(JaegerSpanContext spanContext, T carrier) {
       try {
         decorated.inject(spanContext, carrier);
       } catch (RuntimeException ex) {

--- a/jaeger-core/src/main/java/io/jaegertracing/Reference.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/Reference.java
@@ -22,6 +22,6 @@ import lombok.Value;
 @Value
 public class Reference {
 
-  private final SpanContext spanContext;
+  private final JaegerSpanContext spanContext;
   private final String type;
 }

--- a/jaeger-core/src/main/java/io/jaegertracing/exceptions/SenderException.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/exceptions/SenderException.java
@@ -22,6 +22,11 @@ public class SenderException extends Exception {
     this.droppedSpans = droppedSpans;
   }
 
+  public SenderException(String msg, int droppedSpans) {
+    super(msg);
+    this.droppedSpans = droppedSpans;
+  }
+
   public int getDroppedSpanCount() {
     return droppedSpans;
   }

--- a/jaeger-core/src/main/java/io/jaegertracing/propagation/B3TextMapCodec.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/propagation/B3TextMapCodec.java
@@ -14,9 +14,8 @@
 
 package io.jaegertracing.propagation;
 
-import io.jaegertracing.SpanContext;
-import io.jaegertracing.Tracer;
-import io.jaegertracing.baggage.BaggageRestrictionManager;
+import io.jaegertracing.JaegerSpanContext;
+import io.jaegertracing.JaegerTracer;
 import io.opentracing.propagation.TextMap;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +28,7 @@ import java.util.Map;
  *
  * <pre>{@code
  * b3Codec = new B3TextMapCodec();
- * tracer = new Tracer.Builder(serviceName, reporter, sampler)
+ * tracer = new JaegerTracer.Builder(serviceName, reporter, sampler)
  *                    .registerInjector(Format.Builtin.HTTP_HEADERS, b3Codec)
  *                    .registerExtractor(Format.Builtin.HTTP_HEADERS, b3Codec)
  *                    ...
@@ -40,8 +39,8 @@ import java.util.Map;
  *
  * Note that this codec automatically propagates baggage
  * (with {@value io.jaegertracing.propagation.B3TextMapCodec#BAGGAGE_PREFIX} prefix).
- * Baggage whitelisting can be configured in {@link BaggageRestrictionManager} and then
- * passed to {@link Tracer.Builder#baggageRestrictionManager}
+ * Baggage whitelisting can be configured in {@link io.jaegertracing.baggage.BaggageRestrictionManager} and then
+ * passed to {@link JaegerTracer.Builder#baggageRestrictionManager}
  */
 public class B3TextMapCodec implements Codec<TextMap> {
   protected static final String TRACE_ID_NAME = "X-B3-TraceId";
@@ -70,7 +69,7 @@ public class B3TextMapCodec implements Codec<TextMap> {
   }
 
   @Override
-  public void inject(SpanContext spanContext, TextMap carrier) {
+  public void inject(JaegerSpanContext spanContext, TextMap carrier) {
     carrier.put(TRACE_ID_NAME, HexCodec.toLowerHex(spanContext.getTraceId()));
     if (spanContext.getParentId() != 0L) { // Conventionally, parent id == 0 means the root span
       carrier.put(PARENT_SPAN_ID_NAME, HexCodec.toLowerHex(spanContext.getParentId()));
@@ -86,7 +85,7 @@ public class B3TextMapCodec implements Codec<TextMap> {
   }
 
   @Override
-  public SpanContext extract(TextMap carrier) {
+  public JaegerSpanContext extract(TextMap carrier) {
     Long traceId = null;
     Long spanId = null;
     Long parentId = 0L; // Conventionally, parent id == 0 means the root span
@@ -117,7 +116,7 @@ public class B3TextMapCodec implements Codec<TextMap> {
     }
 
     if (null != traceId && null != parentId && null != spanId) {
-      SpanContext spanContext = new SpanContext(traceId, spanId, parentId, flags);
+      JaegerSpanContext spanContext = new JaegerSpanContext(traceId, spanId, parentId, flags);
       if (baggage != null) {
         spanContext = spanContext.withBaggage(baggage);
       }

--- a/jaeger-core/src/main/java/io/jaegertracing/propagation/CompositeCodec.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/propagation/CompositeCodec.java
@@ -14,7 +14,7 @@
 
 package io.jaegertracing.propagation;
 
-import io.jaegertracing.SpanContext;
+import io.jaegertracing.JaegerSpanContext;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -27,16 +27,16 @@ public class CompositeCodec<T> implements Codec<T> {
   }
 
   @Override
-  public void inject(SpanContext spanContext, T carrier) {
+  public void inject(JaegerSpanContext spanContext, T carrier) {
     for (Codec<T> codec : codecs) {
       codec.inject(spanContext, carrier);
     }
   }
 
   @Override
-  public SpanContext extract(T carrier) {
+  public JaegerSpanContext extract(T carrier) {
     for (Codec<T> codec : codecs) {
-      SpanContext context = codec.extract(carrier);
+      JaegerSpanContext context = codec.extract(carrier);
       if (context != null) {
         return context;
       }

--- a/jaeger-core/src/main/java/io/jaegertracing/propagation/Extractor.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/propagation/Extractor.java
@@ -14,11 +14,11 @@
 
 package io.jaegertracing.propagation;
 
-import io.jaegertracing.SpanContext;
+import io.jaegertracing.JaegerSpanContext;
 
 /**
  * <p>You should implement this class if you want to add possibility to extract information about
- * SpanContext that is provided in your custom propagation scheme. Otherwise you should probably use
+ * JaegerSpanContext that is provided in your custom propagation scheme. Otherwise you should probably use
  * built-in {@link TextMapCodec} or {@link B3TextMapCodec}</p>
  *
  * @see B3TextMapCodec
@@ -28,8 +28,8 @@ import io.jaegertracing.SpanContext;
 public interface Extractor<T> {
 
   /**
-   * <p>Called when {@link io.opentracing.Tracer#extract(io.opentracing.propagation.Format, Object)
-   * Tracer.extract(...)} is used. It should handle the logic behind extracting propagation-scheme
+   * <p>Called when {@link io.opentracing.Tracer#extract(io.opentracing.propagation.Format, Object)}
+   * is used. It should handle the logic behind extracting propagation-scheme
    * specific information from carrier (e.g. http request headers, amqp message headers, etc.).</p>
    *
    * <p>This method must not modify the carrier</p>
@@ -40,10 +40,10 @@ public interface Extractor<T> {
    *
    * @param carrier input that you extract Span information from, usually {@link
    * io.opentracing.propagation.TextMap}.
-   * @return {@link SpanContext} or {@code null} if carrier doesn't contain tracing information, it
+   * @return {@link JaegerSpanContext} or {@code null} if carrier doesn't contain tracing information, it
    * is not valid or is incomplete
    * @see B3TextMapCodec
    * @see TextMapCodec
    */
-  SpanContext extract(T carrier);
+  JaegerSpanContext extract(T carrier);
 }

--- a/jaeger-core/src/main/java/io/jaegertracing/propagation/Injector.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/propagation/Injector.java
@@ -14,12 +14,12 @@
 
 package io.jaegertracing.propagation;
 
-import io.jaegertracing.SpanContext;
+import io.jaegertracing.JaegerSpanContext;
 import io.opentracing.propagation.Format;
 
 /**
  * <p>You should implement this class if you want to add possibility to inject information about
- * SpanContext that is passed between services in your custom propagation scheme. Otherwise you
+ * JaegerSpanContext that is passed between services in your custom propagation scheme. Otherwise you
  * should probably use built-in {@link TextMapCodec} or {@link B3TextMapCodec}</p>
  *
  * @see TextMapCodec
@@ -29,8 +29,8 @@ import io.opentracing.propagation.Format;
 public interface Injector<T> {
 
   /**
-   * <p>Called when {@link io.opentracing.Tracer#inject(io.opentracing.SpanContext, Format, Object)
-   * Tracer.inject(...)} is used. It should handle the logic behind injecting propagation scheme
+   * <p>Called when {@link io.opentracing.Tracer#inject(io.opentracing.SpanContext, Format, Object)}
+   * is used. It should handle the logic behind injecting propagation scheme
    * specific information into the carrier (e.g. http request headers, amqp message headers,
    * etc.).</p>
    *
@@ -43,5 +43,5 @@ public interface Injector<T> {
    * @see B3TextMapCodec
    * @see TextMapCodec
    */
-  void inject(SpanContext spanContext, T carrier);
+  void inject(JaegerSpanContext spanContext, T carrier);
 }

--- a/jaeger-core/src/main/java/io/jaegertracing/propagation/TextMapCodec.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/propagation/TextMapCodec.java
@@ -15,7 +15,7 @@
 package io.jaegertracing.propagation;
 
 import io.jaegertracing.Constants;
-import io.jaegertracing.SpanContext;
+import io.jaegertracing.JaegerSpanContext;
 import io.opentracing.propagation.TextMap;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -54,7 +54,7 @@ public class TextMapCodec implements Codec<TextMap> {
   }
 
   @Override
-  public void inject(SpanContext spanContext, TextMap carrier) {
+  public void inject(JaegerSpanContext spanContext, TextMap carrier) {
     carrier.put(contextKey, encodedValue(spanContext.contextAsString()));
     for (Map.Entry<String, String> entry : spanContext.baggageItems()) {
       carrier.put(keys.prefixedKey(entry.getKey(), baggagePrefix), encodedValue(entry.getValue()));
@@ -62,15 +62,15 @@ public class TextMapCodec implements Codec<TextMap> {
   }
 
   @Override
-  public SpanContext extract(TextMap carrier) {
-    SpanContext context = null;
+  public JaegerSpanContext extract(TextMap carrier) {
+    JaegerSpanContext context = null;
     Map<String, String> baggage = null;
     String debugId = null;
     for (Map.Entry<String, String> entry : carrier) {
       // TODO there should be no lower-case here
       String key = entry.getKey().toLowerCase(Locale.ROOT);
       if (key.equals(contextKey)) {
-        context = SpanContext.contextFromString(decodedValue(entry.getValue()));
+        context = JaegerSpanContext.contextFromString(decodedValue(entry.getValue()));
       } else if (key.equals(Constants.DEBUG_ID_HEADER_KEY)) {
         debugId = decodedValue(entry.getValue());
       } else if (key.startsWith(baggagePrefix)) {
@@ -82,7 +82,7 @@ public class TextMapCodec implements Codec<TextMap> {
     }
     if (context == null) {
       if (debugId != null) {
-        return SpanContext.withDebugId(debugId);
+        return JaegerSpanContext.withDebugId(debugId);
       }
       return null;
     }

--- a/jaeger-core/src/main/java/io/jaegertracing/reporters/CompositeReporter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/reporters/CompositeReporter.java
@@ -14,7 +14,7 @@
 
 package io.jaegertracing.reporters;
 
-import io.jaegertracing.Span;
+import io.jaegertracing.JaegerSpan;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.ToString;
@@ -31,7 +31,7 @@ public class CompositeReporter implements Reporter {
   }
 
   @Override
-  public void report(Span span) {
+  public void report(JaegerSpan span) {
     for (Reporter reporter : this.reporters) {
       reporter.report(span);
     }

--- a/jaeger-core/src/main/java/io/jaegertracing/reporters/InMemoryReporter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/reporters/InMemoryReporter.java
@@ -14,21 +14,21 @@
 
 package io.jaegertracing.reporters;
 
-import io.jaegertracing.Span;
+import io.jaegertracing.JaegerSpan;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.ToString;
 
 @ToString
 public class InMemoryReporter implements Reporter {
-  private final List<Span> spans;
+  private final List<JaegerSpan> spans;
 
   public InMemoryReporter() {
-    this.spans = new ArrayList<Span>();
+    this.spans = new ArrayList<JaegerSpan>();
   }
 
   @Override
-  public void report(Span span) {
+  public void report(JaegerSpan span) {
     synchronized (this) {
       spans.add(span);
     }
@@ -37,7 +37,7 @@ public class InMemoryReporter implements Reporter {
   @Override
   public void close() {}
 
-  public List<Span> getSpans() {
+  public List<JaegerSpan> getSpans() {
     synchronized (this) {
       return spans;
     }

--- a/jaeger-core/src/main/java/io/jaegertracing/reporters/LoggingReporter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/reporters/LoggingReporter.java
@@ -14,7 +14,7 @@
 
 package io.jaegertracing.reporters;
 
-import io.jaegertracing.Span;
+import io.jaegertracing.JaegerSpan;
 import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +38,7 @@ public class LoggingReporter implements Reporter {
   }
 
   @Override
-  public void report(Span span) {
+  public void report(JaegerSpan span) {
     logger.info("Span reported: {}", span);
   }
 

--- a/jaeger-core/src/main/java/io/jaegertracing/reporters/NoopReporter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/reporters/NoopReporter.java
@@ -14,13 +14,13 @@
 
 package io.jaegertracing.reporters;
 
-import io.jaegertracing.Span;
+import io.jaegertracing.JaegerSpan;
 import lombok.ToString;
 
 @ToString
 public class NoopReporter implements Reporter {
   @Override
-  public void report(Span span) {}
+  public void report(JaegerSpan span) {}
 
   @Override
   public void close() {}

--- a/jaeger-core/src/main/java/io/jaegertracing/reporters/RemoteReporter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/reporters/RemoteReporter.java
@@ -14,7 +14,7 @@
 
 package io.jaegertracing.reporters;
 
-import io.jaegertracing.Span;
+import io.jaegertracing.JaegerSpan;
 import io.jaegertracing.exceptions.SenderException;
 import io.jaegertracing.metrics.InMemoryMetricsFactory;
 import io.jaegertracing.metrics.Metrics;
@@ -72,7 +72,7 @@ public class RemoteReporter implements Reporter {
   }
 
   @Override
-  public void report(Span span) {
+  public void report(JaegerSpan span) {
     // Its better to drop spans, than to block here
     boolean added = commandQueue.offer(new AppendCommand(span));
 
@@ -126,9 +126,9 @@ public class RemoteReporter implements Reporter {
   }
 
   class AppendCommand implements Command {
-    private final Span span;
+    private final JaegerSpan span;
 
-    public AppendCommand(Span span) {
+    public AppendCommand(JaegerSpan span) {
       this.span = span;
     }
 

--- a/jaeger-core/src/main/java/io/jaegertracing/reporters/Reporter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/reporters/Reporter.java
@@ -14,14 +14,14 @@
 
 package io.jaegertracing.reporters;
 
-import io.jaegertracing.Span;
+import io.jaegertracing.JaegerSpan;
 
 /**
- * Reporter is the interface Tracer uses to report finished span to something that collects those
+ * Reporter is the interface JaegerTracer uses to report finished span to something that collects those
  * spans. Default implementation is remote reporter that sends spans out of process.
  */
 public interface Reporter {
-  void report(Span span);
+  void report(JaegerSpan span);
 
   void close();
 }

--- a/jaeger-core/src/main/java/io/jaegertracing/senders/NoopSender.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/senders/NoopSender.java
@@ -14,7 +14,7 @@
 
 package io.jaegertracing.senders;
 
-import io.jaegertracing.Span;
+import io.jaegertracing.JaegerSpan;
 import lombok.ToString;
 
 /**
@@ -24,7 +24,7 @@ import lombok.ToString;
 @ToString
 public class NoopSender implements Sender {
   @Override
-  public int append(Span span) {
+  public int append(JaegerSpan span) {
     return 1;
   }
 

--- a/jaeger-core/src/main/java/io/jaegertracing/senders/Sender.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/senders/Sender.java
@@ -14,11 +14,11 @@
 
 package io.jaegertracing.senders;
 
-import io.jaegertracing.Span;
+import io.jaegertracing.JaegerSpan;
 import io.jaegertracing.exceptions.SenderException;
 
 public interface Sender {
-  int append(Span span) throws SenderException;
+  int append(JaegerSpan span) throws SenderException;
 
   int flush() throws SenderException;
 

--- a/jaeger-core/src/main/java/io/jaegertracing/utils/Clock.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/utils/Clock.java
@@ -42,7 +42,7 @@ public interface Clock {
 
   /**
    * @return true if the time returned by {@link #currentTimeMicros()} is accurate enough to
-   * calculate span duration as (end-start). If this method returns false, the {@code Tracer} will
+   * calculate span duration as (end-start). If this method returns false, the {@code JaegerTracer} will
    * use {@link #currentNanoTicks()} for calculating duration instead.
    */
   boolean isMicrosAccurate();

--- a/jaeger-core/src/test/java/io/jaegertracing/JaegerSpanContextTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/JaegerSpanContextTest.java
@@ -20,21 +20,21 @@ import io.jaegertracing.exceptions.EmptyTracerStateStringException;
 import io.jaegertracing.exceptions.MalformedTracerStateStringException;
 import org.junit.Test;
 
-public class SpanContextTest {
+public class JaegerSpanContextTest {
 
   @Test(expected = MalformedTracerStateStringException.class)
   public void testContextFromStringMalformedException() throws Exception {
-    SpanContext.contextFromString("ff:ff:ff");
+    JaegerSpanContext.contextFromString("ff:ff:ff");
   }
 
   @Test(expected = EmptyTracerStateStringException.class)
   public void testContextFromStringEmptyException() throws Exception {
-    SpanContext.contextFromString("");
+    JaegerSpanContext.contextFromString("");
   }
 
   @Test
   public void testContextFromString() throws Exception {
-    SpanContext context = SpanContext.contextFromString("ff:dd:cc:4");
+    JaegerSpanContext context = JaegerSpanContext.contextFromString("ff:dd:cc:4");
     assertEquals(context.getTraceId(), 255);
     assertEquals(context.getSpanId(), 221);
     assertEquals(context.getParentId(), 204);
@@ -50,13 +50,13 @@ public class SpanContextTest {
 
     // I use MIN_VALUE because the most significant bit, and thats when
     // we want to make sure the hex number is positive.
-    SpanContext context = new SpanContext(traceId, spanId, parentId, flags);
+    JaegerSpanContext context = new JaegerSpanContext(traceId, spanId, parentId, flags);
 
     context.contextAsString().split(":");
 
     assertEquals(
         "fffffffffffffff6:fffffffffffffff6:fffffffffffffff6:81", context.contextAsString());
-    SpanContext contextFromStr = SpanContext.contextFromString(context.contextAsString());
+    JaegerSpanContext contextFromStr = JaegerSpanContext.contextFromString(context.contextAsString());
     assertEquals(traceId, contextFromStr.getTraceId());
     assertEquals(spanId, contextFromStr.getSpanId());
     assertEquals(parentId, contextFromStr.getParentId());

--- a/jaeger-core/src/test/java/io/jaegertracing/JaegerTracerResiliencyTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/JaegerTracerResiliencyTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNull;
 import io.jaegertracing.propagation.Codec;
 import io.jaegertracing.reporters.InMemoryReporter;
 import io.jaegertracing.samplers.ConstSampler;
+import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format.Builtin;
 import io.opentracing.propagation.TextMap;
 import java.util.Iterator;
@@ -26,13 +27,13 @@ import java.util.Map.Entry;
 import org.junit.Before;
 import org.junit.Test;
 
-public class TracerResiliencyTest {
+public class JaegerTracerResiliencyTest {
 
-  private Tracer tracer;
+  private JaegerTracer tracer;
 
   @Before
   public void setUpTracer() {
-    tracer = new Tracer.Builder("TracerResiliencyTestService")
+    tracer = new JaegerTracer.Builder("TracerResiliencyTestService")
         .withReporter(new InMemoryReporter())
         .withSampler(new ConstSampler(true))
         .registerExtractor(Builtin.TEXT_MAP, new FaultyCodec())
@@ -42,13 +43,13 @@ public class TracerResiliencyTest {
 
   @Test
   public void shouldFallbackWhenExtractingWithFaultyCodec() {
-    io.opentracing.SpanContext span = tracer.extract(Builtin.TEXT_MAP, new NoopTextMap());
+    SpanContext span = tracer.extract(Builtin.TEXT_MAP, new NoopTextMap());
     assertNull(span);
   }
 
   @Test
   public void shouldFallbackWhenInjectingWithFaultyCodec() {
-    io.opentracing.SpanContext context = tracer.buildSpan("test-span").start().context();
+    SpanContext context = tracer.buildSpan("test-span").start().context();
     tracer.inject(context, Builtin.TEXT_MAP, new NoopTextMap());
   }
 
@@ -56,12 +57,12 @@ public class TracerResiliencyTest {
   private static class FaultyCodec implements Codec<TextMap> {
 
     @Override
-    public SpanContext extract(TextMap carrier) {
+    public JaegerSpanContext extract(TextMap carrier) {
       throw new RuntimeException("Some Codecs can be faulty, this one is.");
     }
 
     @Override
-    public void inject(SpanContext spanContext, TextMap carrier) {
+    public void inject(JaegerSpanContext spanContext, TextMap carrier) {
       throw new RuntimeException("Some Codecs can be faulty, this one is.");
     }
   }

--- a/jaeger-core/src/test/java/io/jaegertracing/JaegerTracerTagsTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/JaegerTracerTagsTest.java
@@ -23,31 +23,31 @@ import java.net.Inet4Address;
 import java.net.InetAddress;
 import org.junit.Test;
 
-public class TracerTagsTest {
+public class JaegerTracerTagsTest {
 
   @Test
   public void testTracerTags() throws Exception {
     InMemoryReporter spanReporter = new InMemoryReporter();
-    Tracer tracer = new Tracer.Builder("x")
+    JaegerTracer tracer = new JaegerTracer.Builder("x")
         .withReporter(spanReporter)
         .withSampler(new ConstSampler(true))
         .withZipkinSharedRpcSpan()
         .withTag("tracer.tag.str", "y")
         .build();
 
-    Span span = (Span) tracer.buildSpan("root").start();
+    JaegerSpan jaegerSpan = (JaegerSpan) tracer.buildSpan("root").start();
 
     // span should only contain sampler tags and no tracer tags
-    assertEquals(2, span.getTags().size());
-    assertEquals(true, span.getTags().containsKey("sampler.type"));
-    assertEquals(true, span.getTags().containsKey("sampler.param"));
-    assertEquals(false, span.getTags().containsKey("tracer.tag.str"));
+    assertEquals(2, jaegerSpan.getTags().size());
+    assertEquals(true, jaegerSpan.getTags().containsKey("sampler.type"));
+    assertEquals(true, jaegerSpan.getTags().containsKey("sampler.param"));
+    assertEquals(false, jaegerSpan.getTags().containsKey("tracer.tag.str"));
   }
 
   @Test
   public void testDefaultHostTags() throws Exception {
     InMemoryReporter spanReporter = new InMemoryReporter();
-    Tracer tracer = new Tracer.Builder("x")
+    JaegerTracer tracer = new JaegerTracer.Builder("x")
         .withReporter(spanReporter)
         .build();
     assertEquals(tracer.getHostName(), tracer.tags().get(Constants.TRACER_HOSTNAME_TAG_KEY));
@@ -60,7 +60,7 @@ public class TracerTagsTest {
     InMemoryReporter spanReporter = new InMemoryReporter();
     String hostname = "myhost";
     String ip = "1.1.1.1";
-    Tracer tracer = new Tracer.Builder("x")
+    JaegerTracer tracer = new JaegerTracer.Builder("x")
         .withReporter(spanReporter)
         .withTag(Constants.TRACER_HOSTNAME_TAG_KEY, hostname)
         .withTag(Constants.TRACER_IP_TAG_KEY, ip)
@@ -74,7 +74,7 @@ public class TracerTagsTest {
   public void testEmptyDeclaredIpTag() throws Exception {
     InMemoryReporter spanReporter = new InMemoryReporter();
     String ip = "";
-    Tracer tracer = new Tracer.Builder("x")
+    JaegerTracer tracer = new JaegerTracer.Builder("x")
             .withReporter(spanReporter)
             .withTag(Constants.TRACER_IP_TAG_KEY, ip)
             .build();
@@ -85,7 +85,7 @@ public class TracerTagsTest {
   public void testShortDeclaredIpTag() throws Exception {
     InMemoryReporter spanReporter = new InMemoryReporter();
     String ip = ":19";
-    Tracer tracer = new Tracer.Builder("x")
+    JaegerTracer tracer = new JaegerTracer.Builder("x")
             .withReporter(spanReporter)
             .withTag(Constants.TRACER_IP_TAG_KEY, ip)
             .build();

--- a/jaeger-core/src/test/java/io/jaegertracing/metrics/InMemoryMetricsFactoryTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/metrics/InMemoryMetricsFactoryTest.java
@@ -16,7 +16,7 @@ package io.jaegertracing.metrics;
 
 import static org.junit.Assert.assertEquals;
 
-import io.jaegertracing.Tracer;
+import io.jaegertracing.JaegerTracer;
 import io.jaegertracing.reporters.InMemoryReporter;
 import io.jaegertracing.samplers.ConstSampler;
 import java.util.Collections;
@@ -102,7 +102,7 @@ public class InMemoryMetricsFactoryTest {
   @Test
   public void emptyValueForTag() {
     InMemoryMetricsFactory metricsFactory = new InMemoryMetricsFactory();
-    Tracer tracer =  new Tracer.Builder("metricsFactoryTest")
+    JaegerTracer tracer =  new JaegerTracer.Builder("metricsFactoryTest")
             .withReporter(new InMemoryReporter())
             .withSampler(new ConstSampler(true))
             .withMetrics(new Metrics(metricsFactory))
@@ -116,7 +116,7 @@ public class InMemoryMetricsFactoryTest {
   @Test
   public void canBeUsedWithMetrics() {
     InMemoryMetricsFactory metricsFactory = new InMemoryMetricsFactory();
-    Tracer tracer = new Tracer.Builder("metricsFactoryTest")
+    JaegerTracer tracer = new JaegerTracer.Builder("metricsFactoryTest")
             .withReporter(new InMemoryReporter())
             .withSampler(new ConstSampler(true))
             .withMetrics(new Metrics(metricsFactory))

--- a/jaeger-core/src/test/java/io/jaegertracing/metrics/NoopMetricsFactoryTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/metrics/NoopMetricsFactoryTest.java
@@ -14,7 +14,7 @@
 
 package io.jaegertracing.metrics;
 
-import io.jaegertracing.Tracer;
+import io.jaegertracing.JaegerTracer;
 import io.jaegertracing.reporters.InMemoryReporter;
 import io.jaegertracing.samplers.ConstSampler;
 import java.util.HashMap;
@@ -88,7 +88,7 @@ public class NoopMetricsFactoryTest {
   @Test
   public void canBeUsedWithMetrics() {
     NoopMetricsFactory metricsFactory = new NoopMetricsFactory();
-    Tracer tracer = new Tracer.Builder("metricsFactoryTest")
+    JaegerTracer tracer = new JaegerTracer.Builder("metricsFactoryTest")
             .withReporter(new InMemoryReporter())
             .withSampler(new ConstSampler(true))
             .withMetrics(new Metrics(metricsFactory))

--- a/jaeger-core/src/test/java/io/jaegertracing/propagation/B3TextMapCodecResiliencyTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/propagation/B3TextMapCodecResiliencyTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertNull;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
-import io.jaegertracing.SpanContext;
+import io.opentracing.SpanContext;
 import io.opentracing.propagation.TextMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/jaeger-core/src/test/java/io/jaegertracing/propagation/B3TextMapCodecTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/propagation/B3TextMapCodecTest.java
@@ -15,11 +15,10 @@
 package io.jaegertracing.propagation;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import io.jaegertracing.SpanContext;
+import io.jaegertracing.JaegerSpanContext;
 import io.opentracing.propagation.TextMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -53,7 +52,7 @@ public class B3TextMapCodecTest {
     textMap.put(B3TextMapCodec.BAGGAGE_PREFIX + "foo", "bar");
     textMap.put("random-foo", "bar");
 
-    SpanContext context = b3Codec.extract(textMap);
+    JaegerSpanContext context = (JaegerSpanContext) b3Codec.extract(textMap);
 
     assertNotNull(HexCodec.lowerHexToUnsignedLong(lower64Bits));
     assertEquals(HexCodec.lowerHexToUnsignedLong(lower64Bits).longValue(), context.getTraceId());
@@ -70,7 +69,7 @@ public class B3TextMapCodecTest {
         .build();
 
     DelegatingTextMap entries = new DelegatingTextMap();
-    SpanContext spanContext = new SpanContext(1, 2, 3, (byte)0)
+    JaegerSpanContext spanContext = new JaegerSpanContext(1, 2, 3, (byte)0)
         .withBaggageItem("foo", "bar");
 
     b3Codec.inject(spanContext, entries);
@@ -89,7 +88,7 @@ public class B3TextMapCodecTest {
         .build();
 
     DelegatingTextMap entries = new DelegatingTextMap();
-    SpanContext spanContext = new SpanContext(1, 2, 3, (byte)0)
+    JaegerSpanContext spanContext = new JaegerSpanContext(1, 2, 3, (byte)0)
         .withBaggageItem("foo", "bar");
 
     b3Codec.inject(spanContext, entries);
@@ -100,7 +99,7 @@ public class B3TextMapCodecTest {
   @Test
   public void testInject() throws Exception {
     DelegatingTextMap textMap = new DelegatingTextMap();
-    b3Codec.inject(new SpanContext(1, 1, 1, SAMPLED), textMap);
+    b3Codec.inject(new JaegerSpanContext(1, 1, 1, SAMPLED), textMap);
 
     assertTrue(textMap.containsKey(B3TextMapCodec.TRACE_ID_NAME));
     assertTrue(textMap.containsKey(B3TextMapCodec.SPAN_ID_NAME));

--- a/jaeger-core/src/test/java/io/jaegertracing/propagation/CompositeCodecTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/propagation/CompositeCodecTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.jaegertracing.SpanContext;
+import io.jaegertracing.JaegerSpanContext;
 import io.opentracing.propagation.TextMap;
 import java.util.Arrays;
 import org.junit.Test;
@@ -32,7 +32,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class CompositeCodecTest {
 
   @Mock
-  private SpanContext mockContext;
+  private JaegerSpanContext mockContext;
 
   @Mock
   private TextMap mockCarrier;

--- a/jaeger-core/src/test/java/io/jaegertracing/senders/InMemorySender.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/senders/InMemorySender.java
@@ -14,7 +14,7 @@
 
 package io.jaegertracing.senders;
 
-import io.jaegertracing.Span;
+import io.jaegertracing.JaegerSpan;
 import io.jaegertracing.exceptions.SenderException;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,9 +26,9 @@ import java.util.concurrent.Semaphore;
  */
 public class InMemorySender implements Sender {
 
-  private List<Span> appended;
-  private List<Span> flushed;
-  private List<Span> received;
+  private List<JaegerSpan> appended;
+  private List<JaegerSpan> flushed;
+  private List<JaegerSpan> received;
   private Semaphore semaphore = new Semaphore(Integer.MAX_VALUE);
 
   public InMemorySender() {
@@ -37,27 +37,29 @@ public class InMemorySender implements Sender {
     received = new ArrayList<>();
   }
 
-  public List<Span> getAppended() {
+  public List<JaegerSpan> getAppended() {
     return new ArrayList<>(appended);
   }
 
-  public List<Span> getFlushed() {
+  public List<JaegerSpan> getFlushed() {
     return new ArrayList<>(flushed);
   }
 
-  public List<Span> getReceived() {
+  public List<JaegerSpan> getReceived() {
     return new ArrayList<>(received);
   }
 
   @Override
-  public int append(Span span) {
+  public int append(JaegerSpan span) {
     try {
       semaphore.acquire();
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     }
+
     appended.add(span);
     received.add(span);
+
     return 0;
   }
 

--- a/jaeger-core/src/test/java/io/jaegertracing/senders/SenderResolverTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/senders/SenderResolverTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import io.jaegertracing.Configuration;
-import io.jaegertracing.Span;
+import io.jaegertracing.JaegerSpan;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -108,7 +108,7 @@ public class SenderResolverTest {
   static class CustomSender implements Sender {
 
     @Override
-    public int append(Span span) {
+    public int append(JaegerSpan span) {
       return 0;
     }
 

--- a/jaeger-crossdock/src/main/java/io/jaegertracing/crossdock/resources/behavior/EndToEndBehavior.java
+++ b/jaeger-crossdock/src/main/java/io/jaegertracing/crossdock/resources/behavior/EndToEndBehavior.java
@@ -14,6 +14,7 @@
 
 package io.jaegertracing.crossdock.resources.behavior;
 
+import io.jaegertracing.JaegerTracer;
 import io.jaegertracing.crossdock.api.CreateTracesRequest;
 import io.jaegertracing.metrics.Metrics;
 import io.jaegertracing.metrics.NoopMetricsFactory;
@@ -52,7 +53,7 @@ public class EndToEndBehavior {
     tracers = new HashMap<>();
     tracers.put(RemoteControlledSampler.TYPE, getRemoteTracer(metrics, reporter, serviceName, samplingHostPort));
     tracers.put(ConstSampler.TYPE,
-        new io.jaegertracing.Tracer.Builder(serviceName).withReporter(reporter).withSampler(constSampler).build());
+        new JaegerTracer.Builder(serviceName).withReporter(reporter).withSampler(constSampler).build());
   }
 
   private Tracer getRemoteTracer(Metrics metrics, Reporter reporter, String serviceName, String samplingHostPort) {
@@ -66,7 +67,7 @@ public class EndToEndBehavior {
         .withPollingInterval(5000)
         .build();
 
-    return new io.jaegertracing.Tracer.Builder(serviceName)
+    return new JaegerTracer.Builder(serviceName)
         .withReporter(reporter)
         .withSampler(remoteSampler)
         .build();

--- a/jaeger-crossdock/src/main/java/io/jaegertracing/crossdock/resources/behavior/TraceBehavior.java
+++ b/jaeger-crossdock/src/main/java/io/jaegertracing/crossdock/resources/behavior/TraceBehavior.java
@@ -15,8 +15,8 @@
 package io.jaegertracing.crossdock.resources.behavior;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jaegertracing.Span;
-import io.jaegertracing.SpanContext;
+import io.jaegertracing.JaegerSpan;
+import io.jaegertracing.JaegerSpanContext;
 import io.jaegertracing.crossdock.Constants;
 import io.jaegertracing.crossdock.JerseyServer;
 import io.jaegertracing.crossdock.api.Downstream;
@@ -87,13 +87,13 @@ public class TraceBehavior {
   }
 
   private ObservedSpan observeSpan() {
-    Span span = (Span)tracer.activeSpan();
+    JaegerSpan span = (JaegerSpan) tracer.activeSpan();
     if (tracer.activeSpan() == null) {
       log.error("No span found");
       return new ObservedSpan("no span found", false, "no span found");
     }
 
-    SpanContext context = span.context();
+    JaegerSpanContext context = (JaegerSpanContext) span.context();
     String traceId = String.format("%x", context.getTraceId());
     boolean sampled = context.isSampled();
     String baggage = span.getBaggageItem(Constants.BAGGAGE_KEY);

--- a/jaeger-crossdock/src/main/java/io/jaegertracing/crossdock/resources/behavior/http/TraceBehaviorResource.java
+++ b/jaeger-crossdock/src/main/java/io/jaegertracing/crossdock/resources/behavior/http/TraceBehaviorResource.java
@@ -15,12 +15,12 @@
 package io.jaegertracing.crossdock.resources.behavior.http;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jaegertracing.Span;
 import io.jaegertracing.crossdock.Constants;
 import io.jaegertracing.crossdock.api.JoinTraceRequest;
 import io.jaegertracing.crossdock.api.StartTraceRequest;
 import io.jaegertracing.crossdock.api.TraceResponse;
 import io.jaegertracing.crossdock.resources.behavior.TraceBehavior;
+import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
 import javax.ws.rs.Consumes;
@@ -52,7 +52,7 @@ public class TraceBehaviorResource {
     log.info("http:start_trace request: {}", mapper.writeValueAsString(startRequest));
     // TODO should be starting new root span
     String baggage = startRequest.getBaggage();
-    Span span = (Span)tracer.activeSpan();
+    Span span = tracer.activeSpan();
     span.setBaggageItem(Constants.BAGGAGE_KEY, baggage);
     if (startRequest.isSampled()) {
       Tags.SAMPLING_PRIORITY.set(span, 1);

--- a/jaeger-crossdock/src/test/java/io/jaegertracing/crossdock/resources/behavior/http/EndToEndBehaviorResourceTest.java
+++ b/jaeger-crossdock/src/test/java/io/jaegertracing/crossdock/resources/behavior/http/EndToEndBehaviorResourceTest.java
@@ -17,7 +17,8 @@ package io.jaegertracing.crossdock.resources.behavior.http;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import io.jaegertracing.Span;
+import io.jaegertracing.JaegerSpan;
+import io.jaegertracing.JaegerTracer;
 import io.jaegertracing.crossdock.api.CreateTracesRequest;
 import io.jaegertracing.crossdock.resources.behavior.EndToEndBehavior;
 import io.jaegertracing.reporters.InMemoryReporter;
@@ -37,7 +38,7 @@ public class EndToEndBehaviorResourceTest {
   public void setUp() throws Exception {
     reporter = new InMemoryReporter();
     Tracer tracer =
-        new io.jaegertracing.Tracer.Builder("crossdock-java")
+        new JaegerTracer.Builder("crossdock-java")
             .withReporter(reporter)
             .withSampler(new ConstSampler(true))
             .build();
@@ -57,9 +58,9 @@ public class EndToEndBehaviorResourceTest {
     validateSpans(reporter.getSpans(), request);
   }
 
-  private void validateSpans(List<Span> spans, CreateTracesRequest request) {
+  private void validateSpans(List<JaegerSpan> spans, CreateTracesRequest request) {
     assertEquals(request.getCount(), spans.size());
-    for (Span s : spans) {
+    for (JaegerSpan s : spans) {
       assertEquals(request.getOperation(), s.getOperationName());
       Map<String, Object> tags = s.getTags();
       for (Map.Entry<String, String> entry : request.getTags().entrySet()) {

--- a/jaeger-crossdock/src/test/java/io/jaegertracing/crossdock/resources/behavior/http/TraceBehaviorResourceTest.java
+++ b/jaeger-crossdock/src/test/java/io/jaegertracing/crossdock/resources/behavior/http/TraceBehaviorResourceTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertNull;
 import io.jaegertracing.Configuration;
 import io.jaegertracing.Configuration.ReporterConfiguration;
 import io.jaegertracing.Configuration.SamplerConfiguration;
-import io.jaegertracing.Span;
+import io.jaegertracing.JaegerSpanContext;
 import io.jaegertracing.crossdock.Constants;
 import io.jaegertracing.crossdock.JerseyServer;
 import io.jaegertracing.crossdock.api.Downstream;
@@ -104,7 +104,7 @@ public class TraceBehaviorResourceTest {
   @Test
   public void testStartTraceHttp() throws Exception {
     Scope scope = server.getTracer().buildSpan("root").startActive(true);
-    String expectedTraceId = String.format("%x", ((Span)scope.span()).context().getTraceId());
+    String expectedTraceId = String.format("%x", ((JaegerSpanContext)scope.span().context()).getTraceId());
     String expectedBaggage = "baggage-example";
 
     Downstream downstream =
@@ -153,7 +153,7 @@ public class TraceBehaviorResourceTest {
 
     assertNotNull(traceResponse.getDownstream());
     validateTraceResponse(traceResponse, String.format("%x",
-        ((Span)scope.span()).context().getTraceId()), expectedBaggage, 2);
+        ((JaegerSpanContext)scope.span().context()).getTraceId()), expectedBaggage, 2);
     scope.close();
   }
 

--- a/jaeger-micrometer/src/test/java/io/jaegertracing/micrometer/MicrometerTest.java
+++ b/jaeger-micrometer/src/test/java/io/jaegertracing/micrometer/MicrometerTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import io.jaegertracing.Configuration;
-import io.jaegertracing.Tracer;
+import io.jaegertracing.JaegerTracer;
 import io.jaegertracing.metrics.Metrics;
 import io.jaegertracing.metrics.Timer;
 import io.jaegertracing.samplers.ConstSampler;
@@ -125,7 +125,7 @@ public class MicrometerTest {
   @Test
   public void testExposedMetrics() {
     Configuration configuration = new Configuration("exposedmetrics");
-    final Tracer tracer = configuration
+    final JaegerTracer tracer = configuration
             .getTracerBuilder()
             .withMetrics(metrics)
             .build();
@@ -157,7 +157,7 @@ public class MicrometerTest {
   public void validateMetricCounts() throws InterruptedException {
     Sampler constantSampler = new ConstSampler(true);
     Configuration configuration = new Configuration("validateMetricCounts");
-    Tracer tracer = configuration
+    JaegerTracer tracer = configuration
             .getTracerBuilder()
             .withSampler(constantSampler)
             .withMetrics(metrics)
@@ -209,7 +209,7 @@ public class MicrometerTest {
     assertEquals(1, registry.find("jaeger:started_spans").counter().count(), 0);
   }
 
-  private void createSomeSpans(Tracer tracer) {
+  private void createSomeSpans(JaegerTracer tracer) {
     for (int i = 0; i < 10; i++) {
       Span span = tracer.buildSpan("metricstest")
               .withTag("foo", "bar" + i)

--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/senders/ThriftSender.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/senders/ThriftSender.java
@@ -14,10 +14,10 @@
 
 package io.jaegertracing.thrift.senders;
 
-import io.jaegertracing.Span;
+import io.jaegertracing.JaegerSpan;
 import io.jaegertracing.exceptions.SenderException;
-import io.jaegertracing.thrift.reporters.protocols.JaegerThriftSpanConverter;
 import io.jaegertracing.senders.Sender;
+import io.jaegertracing.thrift.reporters.protocols.JaegerThriftSpanConverter;
 import io.jaegertracing.thrift.reporters.protocols.ThriftUdpTransport;
 import io.jaegertracing.thriftjava.Process;
 import java.util.ArrayList;
@@ -43,7 +43,7 @@ public abstract class ThriftSender extends ThriftSenderBase implements Sender {
   }
 
   @Override
-  public int append(Span span) throws SenderException {
+  public int append(JaegerSpan span) throws SenderException {
     if (process == null) {
       process = new Process(span.getTracer().getServiceName());
       process.setTags(JaegerThriftSpanConverter.buildTags(span.getTracer().tags()));

--- a/jaeger-tracerresolver/src/main/java/io/jaegertracing/tracerresolver/JaegerTracerResolver.java
+++ b/jaeger-tracerresolver/src/main/java/io/jaegertracing/tracerresolver/JaegerTracerResolver.java
@@ -15,12 +15,13 @@
 package io.jaegertracing.tracerresolver;
 
 import io.jaegertracing.Configuration;
+import io.opentracing.Tracer;
 import io.opentracing.contrib.tracerresolver.TracerResolver;
 
 public class JaegerTracerResolver extends TracerResolver {
 
   @Override
-  protected io.opentracing.Tracer resolve() {
+  protected Tracer resolve() {
     return Configuration.fromEnv().getTracer();
   }
 

--- a/jaeger-tracerresolver/src/test/java/io/jaegertracing/tracerresolver/JaegerTracerResolverTest.java
+++ b/jaeger-tracerresolver/src/test/java/io/jaegertracing/tracerresolver/JaegerTracerResolverTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import io.jaegertracing.Configuration;
+import io.jaegertracing.JaegerTracer;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.tracerresolver.TracerResolver;
 import org.junit.After;
@@ -44,7 +45,7 @@ public class JaegerTracerResolverTest {
     System.setProperty(Configuration.JAEGER_SERVICE_NAME, "MyService");
     Tracer tracer = TracerResolver.resolveTracer();
     assertNotNull(tracer);
-    assertTrue(tracer instanceof io.jaegertracing.Tracer);
+    assertTrue(tracer instanceof JaegerTracer);
   }
 
 }

--- a/jaeger-zipkin/build.gradle
+++ b/jaeger-zipkin/build.gradle
@@ -2,7 +2,6 @@ description = 'Integration library for Zipkin'
 
 dependencies {
     compile group: 'io.zipkin.reporter2', name: 'zipkin-sender-urlconnection', version: '2.7.6'
-
     compile group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
 
     compile project(':jaeger-core')

--- a/jaeger-zipkin/src/main/java/io/jaegertracing/senders/zipkin/ZipkinSender.java
+++ b/jaeger-zipkin/src/main/java/io/jaegertracing/senders/zipkin/ZipkinSender.java
@@ -24,6 +24,7 @@ import com.twitter.zipkin.thriftjava.BinaryAnnotation;
 import com.twitter.zipkin.thriftjava.Endpoint;
 import com.twitter.zipkin.thriftjava.Span;
 import com.twitter.zipkin.thriftjava.zipkincoreConstants;
+import io.jaegertracing.JaegerSpan;
 import io.jaegertracing.exceptions.SenderException;
 import io.jaegertracing.senders.Sender;
 import java.io.IOException;
@@ -47,7 +48,7 @@ import zipkin2.reporter.urlconnection.URLConnectionSender;
  *
  * <pre>{@code
  * reporter = new RemoteReporter(ZipkinSender.create("http://localhost:9411/api/v1/spans"));
- * tracer = new Tracer.Builder(serviceName, reporter, sampler)
+ * tracer = new JaegerTracer.Builder(serviceName, reporter, sampler)
  *                    ...
  * }</pre>
  *
@@ -110,8 +111,8 @@ public final class ZipkinSender implements Sender {
    * a single thread that calls this append function
    */
   @Override
-  public int append(io.jaegertracing.Span span) throws SenderException {
-    byte[] next = encoder.encode(backFillHostOnAnnotations(ThriftSpanConverter.convertSpan(span)));
+  public int append(JaegerSpan span) throws SenderException {
+    byte[] next = encoder.encode(backFillHostOnAnnotations(ThriftSpanConverter.convertSpan((JaegerSpan) span)));
     int messageSizeOfNextSpan = delegate.messageSizeInBytes(Collections.singletonList(next));
     // don't enqueue something larger than we can drain
     if (messageSizeOfNextSpan > delegate.messageMaxBytes()) {

--- a/jaeger-zipkin/src/main/java/io/jaegertracing/zipkin/ConverterUtil.java
+++ b/jaeger-zipkin/src/main/java/io/jaegertracing/zipkin/ConverterUtil.java
@@ -14,22 +14,22 @@
 
 package io.jaegertracing.zipkin;
 
-import io.jaegertracing.Span;
+import io.jaegertracing.JaegerSpan;
 import io.opentracing.tag.Tags;
 
 /**
  * Logic that is common to both Thrift v1 and JSON v2 senders
  */
 public class ConverterUtil {
-  public static boolean isRpcServer(Span span) {
-    return Tags.SPAN_KIND_SERVER.equals(span.getTags().get(Tags.SPAN_KIND.getKey()));
+  public static boolean isRpcServer(JaegerSpan jaegerSpan) {
+    return Tags.SPAN_KIND_SERVER.equals(jaegerSpan.getTags().get(Tags.SPAN_KIND.getKey()));
   }
 
-  public static boolean isRpc(Span span) {
-    return isRpcServer(span) || isRpcClient(span);
+  public static boolean isRpc(JaegerSpan jaegerSpan) {
+    return isRpcServer(jaegerSpan) || isRpcClient(jaegerSpan);
   }
 
-  public static boolean isRpcClient(Span span) {
-    return Tags.SPAN_KIND_CLIENT.equals(span.getTags().get(Tags.SPAN_KIND.getKey()));
+  public static boolean isRpcClient(JaegerSpan jaegerSpan) {
+    return Tags.SPAN_KIND_CLIENT.equals(jaegerSpan.getTags().get(Tags.SPAN_KIND.getKey()));
   }
 }

--- a/jaeger-zipkin/src/main/java/io/jaegertracing/zipkin/reporters/ZipkinV2Reporter.java
+++ b/jaeger-zipkin/src/main/java/io/jaegertracing/zipkin/reporters/ZipkinV2Reporter.java
@@ -14,21 +14,24 @@
 
 package io.jaegertracing.zipkin.reporters;
 
+import io.jaegertracing.JaegerSpan;
 import io.jaegertracing.reporters.Reporter;
 import io.jaegertracing.zipkin.V2SpanConverter;
+import zipkin2.Span;
+import zipkin2.reporter.AsyncReporter;
 
 /**
- * Wrapper around a zipkin v2 AsyncReporter that reports spans using the newer v2 Span class
+ * Wrapper around a zipkin v2 AsyncReporter that reports spans using the newer v2 JaegerSpan class
  */
 public class ZipkinV2Reporter implements Reporter {
-  public final zipkin2.reporter.AsyncReporter<zipkin2.Span> reporter;
+  public final AsyncReporter<zipkin2.Span> reporter;
 
-  public ZipkinV2Reporter(zipkin2.reporter.AsyncReporter<zipkin2.Span> reporter) {
+  public ZipkinV2Reporter(AsyncReporter<Span> reporter) {
     this.reporter = reporter;
   }
 
   @Override
-  public void report(io.jaegertracing.Span span) {
+  public void report(JaegerSpan span) {
     reporter.report(V2SpanConverter.convertSpan(span));
   }
 

--- a/jaeger-zipkin/src/test/java/io/jaegertracing/zipkin/reporters/ZipkinV2ReporterTest.java
+++ b/jaeger-zipkin/src/test/java/io/jaegertracing/zipkin/reporters/ZipkinV2ReporterTest.java
@@ -16,8 +16,8 @@ package io.jaegertracing.zipkin.reporters;
 
 import static org.junit.Assert.assertEquals;
 
-import io.jaegertracing.Span;
-import io.jaegertracing.Tracer;
+import io.jaegertracing.JaegerSpan;
+import io.jaegertracing.JaegerTracer;
 import io.jaegertracing.metrics.InMemoryMetricsFactory;
 import io.jaegertracing.reporters.Reporter;
 import io.jaegertracing.samplers.ConstSampler;
@@ -38,7 +38,7 @@ public class ZipkinV2ReporterTest {
   Sender sender;
   AsyncReporter<zipkin2.Span> zipkinReporter;
   Reporter reporter;
-  Tracer tracer;
+  JaegerTracer tracer;
 
   @Before
   public void setup() throws Exception {
@@ -53,7 +53,7 @@ public class ZipkinV2ReporterTest {
 
     reporter = new ZipkinV2Reporter(zipkinReporter);
 
-    tracer = new Tracer.Builder("test-sender")
+    tracer = new JaegerTracer.Builder("test-sender")
             .withReporter(reporter)
             .withSampler(new ConstSampler(true))
             .withMetricsFactory(new InMemoryMetricsFactory())
@@ -62,10 +62,10 @@ public class ZipkinV2ReporterTest {
 
   @Test
   public void testConvertsAndSendsSpan() throws Exception {
-    Span jaegerSpan = (Span)tracer.buildSpan("raza").start();
-    jaegerSpan.finish();
+    JaegerSpan span = (JaegerSpan) tracer.buildSpan("raza").start();
+    span.finish();
 
-    reporter.report(jaegerSpan);
+    reporter.report(span);
     zipkinReporter.flush();
 
     List<List<zipkin2.Span>> spans = zipkinRule.getTraces();


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #434

## Short description of the changes
* Rename Jaeger's `Span` to `JaegerSpan`
* Rename Jaeger's `SpanContext` to `JaegerSpanContext`
* Rename Jaeger's `Tracer` to `JaegerTracer`

Not included in this PR are the decisions about what should be public and what should be internal API. This will be handled in #396.