### PR TITLE
Address build warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,7 @@ subprojects {
     }
 
     dependencies {
+        annotationProcessor 'org.projectlombok:lombok:1.16.18'
         compileOnly 'org.projectlombok:lombok:1.16.18'
         compileOnly 'org.codehaus.mojo:animal-sniffer-annotations:1.16'
     }

--- a/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
@@ -421,8 +421,8 @@ public class Configuration {
                 addCodec(codecs, Format.Builtin.TEXT_MAP, new TextMapCodec(false));
                 break;
               case B3:
-                addCodec(codecs, Format.Builtin.HTTP_HEADERS, new B3TextMapCodec());
-                addCodec(codecs, Format.Builtin.TEXT_MAP, new B3TextMapCodec());
+                addCodec(codecs, Format.Builtin.HTTP_HEADERS, new B3TextMapCodec.Builder().build());
+                addCodec(codecs, Format.Builtin.TEXT_MAP, new B3TextMapCodec.Builder().build());
                 break;
               default:
                 log.error("Unhandled propagation format '" + format + "'");

--- a/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
@@ -368,8 +368,9 @@ public class ConfigurationTest {
     assertInjectExtract(configuration.getTracer(), Builtin.HTTP_HEADERS, spanContext, false);
   }
 
+  @SuppressWarnings("unchecked")
   private <C> void assertInjectExtract(io.opentracing.Tracer tracer, Format<C> format, SpanContext contextToInject,
-      boolean injectMapIsEmpty) {
+                                       boolean injectMapIsEmpty) {
     HashMap<String, String> injectMap = new HashMap<>();
     tracer.inject(contextToInject, format, (C)new TextMapInjectAdapter(injectMap));
     assertEquals(injectMapIsEmpty, injectMap.isEmpty());

--- a/jaeger-core/src/test/java/io/jaegertracing/TracerTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/TracerTest.java
@@ -17,7 +17,7 @@ package io.jaegertracing;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/jaeger-core/src/test/java/io/jaegertracing/propagation/B3TextMapCodecResiliencyTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/propagation/B3TextMapCodecResiliencyTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 @RunWith(DataProviderRunner.class)
 public class B3TextMapCodecResiliencyTest {
 
-  private B3TextMapCodec sut = new B3TextMapCodec();
+  private B3TextMapCodec sut = new B3TextMapCodec.Builder().build();
 
   @DataProvider
   public static Object[][] maliciousInputs() {

--- a/jaeger-core/src/test/java/io/jaegertracing/propagation/B3TextMapCodecTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/propagation/B3TextMapCodecTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 public class B3TextMapCodecTest {
   static final byte SAMPLED = 1;
 
-  B3TextMapCodec b3Codec = new B3TextMapCodec();
+  B3TextMapCodec b3Codec = new B3TextMapCodec.Builder().build();
 
   @Test
   public void downgrades128BitTraceIdToLower64Bits() throws Exception {

--- a/jaeger-zipkin/src/test/java/io/jaegertracing/zipkin/reporters/ZipkinV2ReporterTest.java
+++ b/jaeger-zipkin/src/test/java/io/jaegertracing/zipkin/reporters/ZipkinV2ReporterTest.java
@@ -28,6 +28,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import zipkin.junit.ZipkinRule;
 import zipkin2.codec.Encoding;
+import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
 
@@ -36,7 +37,7 @@ public class ZipkinV2ReporterTest {
   @Rule public ZipkinRule zipkinRule = new ZipkinRule();
 
   Sender sender;
-  zipkin2.reporter.AsyncReporter zipkinReporter;
+  AsyncReporter<zipkin2.Span> zipkinReporter;
   Reporter reporter;
   Tracer tracer;
 


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- Clear up build warnings.

## Short description of the changes
- For each warning that was being shown, there's one small change either in the code or in the build file.

Before:
```
$ ./gradlew clean check

> Configure project :
0.29.1-SNAPSHOT

> Task :jaeger-core:compileJava
Note: /mnt/storage/jpkroehling/Projects/src/github.com/jaegertracing/jaeger-client-java/jaeger-core/src/main/java/io/jaegertracing/Configuration.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

> Task :jaeger-core:compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: /mnt/storage/jpkroehling/Projects/src/github.com/jaegertracing/jaeger-client-java/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :jaeger-core:test

io.jaegertracing.reporters.RemoteReporterTest > testCloseWhenQueueFull SKIPPED

> Task :jaeger-thrift:compileJava
warning: [options] bootstrap class path not set in conjunction with -source 1.6

> Task :jaeger-zipkin:compileTestJava
Note: /mnt/storage/jpkroehling/Projects/src/github.com/jaegertracing/jaeger-client-java/jaeger-zipkin/src/test/java/io/jaegertracing/zipkin/reporters/ZipkinV2ReporterTest.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 5.0.
See https://docs.gradle.org/4.7/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1m 6s
59 actionable tasks: 47 executed, 12 up-to-date
```

After:
```
$ ./gradlew clean check

> Configure project :
0.29.1-SNAPSHOT

> Task :jaeger-core:test

io.jaegertracing.reporters.RemoteReporterTest > testCloseWhenQueueFull SKIPPED

> Task :jaeger-thrift:compileJava
warning: [options] bootstrap class path not set in conjunction with -source 1.6

BUILD SUCCESSFUL in 1m 13s
59 actionable tasks: 42 executed, 17 up-to-date
```

