### PR TITLE
Upgrades internals to Zipkin v2 library

### DIFF
--- a/jaeger-zipkin/build.gradle
+++ b/jaeger-zipkin/build.gradle
@@ -1,18 +1,12 @@
 description = 'Integration library for Zipkin'
 
 dependencies {
-    compile group: 'io.zipkin.reporter', name: 'zipkin-reporter', version: '1.1.2'
-    compile group: 'io.zipkin.reporter', name: 'zipkin-sender-urlconnection', version: '1.1.2'
-
-    compile group: 'io.zipkin.java', name: 'zipkin', version: '2.8.1'
-    compile group: 'io.zipkin.reporter2', name: 'zipkin-reporter', version: '2.6.0'
+    compile group: 'io.zipkin.reporter2', name: 'zipkin-sender-urlconnection', version: '2.7.6'
 
     compile project(':jaeger-core')
     compile project(':jaeger-thrift')
 
-    testCompile group: 'io.zipkin.reporter2', name: 'zipkin-sender-urlconnection', version: '2.6.0'
-    testCompile group: 'junit', name: 'junit', version: junitVersion
-    testCompile group: 'io.zipkin.java', name: 'zipkin-junit', version: '2.7.1'
+    testCompile group: 'io.zipkin.zipkin2', name: 'zipkin-junit', version: '2.9.4'
     testCompile group: 'com.tngtech.java', name: 'junit-dataprovider', version: junitDataProviderVersion
 
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'

--- a/jaeger-zipkin/src/main/java/io/jaegertracing/senders/zipkin/ThriftSpanEncoder.java
+++ b/jaeger-zipkin/src/main/java/io/jaegertracing/senders/zipkin/ThriftSpanEncoder.java
@@ -16,17 +16,22 @@ package io.jaegertracing.senders.zipkin;
 
 import com.twitter.zipkin.thriftjava.Span;
 import java.io.ByteArrayOutputStream;
+import java.util.List;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.transport.TIOStreamTransport;
-import zipkin.reporter.Encoder;
-import zipkin.reporter.Encoding;
+import zipkin2.codec.BytesEncoder;
+import zipkin2.codec.Encoding;
 
-final class ThriftSpanEncoder implements Encoder<Span> {
+final class ThriftSpanEncoder implements BytesEncoder<Span> {
 
   @Override
   public Encoding encoding() {
     return Encoding.THRIFT;
+  }
+
+  @Override public int sizeInBytes(Span input) {
+    throw new UnsupportedOperationException("unused by internal code");
   }
 
   @Override
@@ -39,6 +44,10 @@ final class ThriftSpanEncoder implements Encoder<Span> {
     } catch (TException e) {
       throw new AssertionError(e);
     }
+  }
+
+  @Override public byte[] encodeList(List<Span> input) {
+    throw new UnsupportedOperationException("unused by internal code");
   }
 
   static class ReusableTBinaryProtocol extends TBinaryProtocol {

--- a/jaeger-zipkin/src/test/java/io/jaegertracing/senders/zipkin/ThriftSpanEncoderTest.java
+++ b/jaeger-zipkin/src/test/java/io/jaegertracing/senders/zipkin/ThriftSpanEncoderTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.jaegertracing.senders.zipkin;
+
+import java.util.Collections;
+import org.junit.Test;
+
+// This file is here to satisfy unit test coverage of unsupported methods
+public class ThriftSpanEncoderTest {
+
+  ThriftSpanEncoder encoder = new ThriftSpanEncoder();
+
+  /** sizeInBytes isn't used, but the fact we don't support it kicks test coverage */
+  @Test(expected = UnsupportedOperationException.class)
+  public void sizeInBytes_unsupported() {
+    encoder.sizeInBytes(new com.twitter.zipkin.thriftjava.Span());
+  }
+
+  /** encodeList isn't used, but the fact we don't support it kicks test coverage */
+  @Test(expected = UnsupportedOperationException.class)
+  public void encodeList_unsupported() {
+    encoder.encodeList(Collections.emptyList());
+  }
+}

--- a/jaeger-zipkin/src/test/java/io/jaegertracing/zipkin/reporters/ZipkinV2ReporterTest.java
+++ b/jaeger-zipkin/src/test/java/io/jaegertracing/zipkin/reporters/ZipkinV2ReporterTest.java
@@ -26,12 +26,11 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import zipkin.junit.ZipkinRule;
 import zipkin2.codec.Encoding;
+import zipkin2.junit.ZipkinRule;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.urlconnection.URLConnectionSender;
-
 
 public class ZipkinV2ReporterTest {
   @Rule public ZipkinRule zipkinRule = new ZipkinRule();
@@ -69,7 +68,7 @@ public class ZipkinV2ReporterTest {
     reporter.report(jaegerSpan);
     zipkinReporter.flush();
 
-    List<List<zipkin.Span>> spans = zipkinRule.getTraces();
-    assertEquals(spans.get(0).get(0).name, "raza");
+    List<List<zipkin2.Span>> spans = zipkinRule.getTraces();
+    assertEquals(spans.get(0).get(0).name(), "raza");
   }
 }


### PR DESCRIPTION
## Which problem is this PR solving?
The current zipkin integration encourages use of a dead version of a library (io.zipkin.reporter)

## Short description of the changes
Recent version of io.zipkin.zipkin2:zipkin has been backported to
support thrift encoding. This updates the corresponding sender here to
use that, notably to migrate off the io.zipkin.reporter libraries which
receive no updates.