### PR TITLE
Adjust thrift shadow configuration and version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ ext.developmentVersion = getProperty('developmentVersion','0.29.1-SNAPSHOT')
 
 ext.opentracingVersion = getProperty('opentracingVersion','0.31.0')
 ext.guavaVersion = getProperty('guavaVersion','18.0')
-ext.apacheThriftVersion = getProperty('apacheThriftVersion','0.9.2')
+ext.apacheThriftVersion = getProperty('apacheThriftVersion','0.11.0')
 ext.jerseyVersion = getProperty('jerseyVersion','2.22.2')
 ext.slf4jVersion = getProperty('slf4jVersion','1.7.25')
 ext.gsonVersion = getProperty('gsonVersion','2.8.2')

--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -42,8 +42,11 @@ checkstyleTest.enabled = false
 
 shadowJar {
     baseName = 'jaeger-thrift'
-    relocate 'org.apache.thrift', 'org.shadow.apache.thrift92'
-    relocate 'okhttp', 'jaeger.okhttp'
+    relocate 'com.google.gson'  , 'jaeger.com.google.gson'
+    relocate 'com.twitter'      , 'jaeger.com.twitter'
+    relocate 'okhttp'           , 'jaeger.okhttp'
+    relocate 'okio'             , 'jaeger.okio'
+    relocate 'org.apache'       , 'jaeger.org.apache'
     classifier 'shadow'
 }
 

--- a/travis/docker-thrift/thrift
+++ b/travis/docker-thrift/thrift
@@ -2,7 +2,7 @@
 
 pwd=$(dirname ${PWD})
 
-THRIFT_VER=0.9.2
+THRIFT_VER=0.11.0
 THRIFT_IMG=thrift:${THRIFT_VER}
 THRIFT="docker run --rm -u $(id -u) -v ${pwd}:/data ${THRIFT_IMG} thrift"
 


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- Resolves #228 (How to use jaeger-thrift classifier thrift92 right?)
- Resolves #450 (Align shadow relocations)

## Short description of the changes
- Bump Thrift version (like #326)
- Relocate most dependencies from `package` to `jaeger.package`. Exceptions: OpenTracing, SLF4J. Result: https://paste.fedoraproject.org/paste/BeuGC4779A1dlt~AqLPD4g
