### PR TITLE
Make jaeger-thrift's shaded JAR the default one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ way to add such header is to run `./gradlew licenseFormat`.
 
 ```
 /*
- * Copyright (c) 2017, The Jaeger Authors
+ * Copyright (c) 2018, The Jaeger Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 # Jaeger's Tracing Instrumentation Library for Java
 
  * Intended to be used with [Jaeger](https://github.com/jaegertracing/jaeger) backend, but can also be configured to send traces to Zipkin.
- * Implement [Java OpenTracing API](https://github.com/opentracing/opentracing-java).
+ * Implements [OpenTracing Java API](https://github.com/opentracing/opentracing-java).
  * Supports Java 1.6 and above
 
-#### Package rename to io.jaegertracing
-Groupid `com.uber.jaeger` has been deprecated and moved to a different [repository](https://github.com/jaegertracing/legacy-client-java).
-Please switch to `io.jaegertracing`. Old groupid will be maintained only for bug fixes.
+#### Package rename to `io.jaegertracing`
+
+The group ID `com.uber.jaeger` has been deprecated and moved to a different [repository][legacy-client-java].
+Please switch to `io.jaegertracing`, as the old group ID will be maintained only for bug fixes.
 
 # Contributing and Developing
 
@@ -19,51 +20,35 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md).
 Click through for more detailed docs on specific modules.
 
  * [jaeger-core](./jaeger-core): the core implementation of the OpenTracing API
+ * [jaeger-thrift](./jaeger-thrift): the main dependency to include in your project, sending data to the backend using Thrift (default)
  
 ## Add-on Modules
 
- * [jaeger-zipkin](./jaeger-zipkin): compatibility layer for using Jaeger tracer as Zipkin-compatible implementation
- * [jaeger-micrometer](./jaeger-micrometer): a metrics provider, to report internal Jaeger metrics to third-party backends, such as Prometheus
- * [jaeger-tracerresolver](./jaeger-tracerresolver): a tracer resolver for Jaeger tracer.
+ * [jaeger-zipkin](./jaeger-zipkin): compatibility layer for using the Jaeger Tracer to Zipkin-compatible backends
+ * [jaeger-micrometer](./jaeger-micrometer): a metrics provider, to report internal Jaeger Client metrics to third-party backends, such as Prometheus
+ * [jaeger-tracerresolver](./jaeger-tracerresolver): an [OpenTracing `TracingResolver`][tracerresolver] for the Jaeger Tracer.
 
 ## Importing Dependencies
-All artifacts are published to Maven Central. 
-Snapshot artifacts are also published to
-[Sonatype](https://oss.sonatype.org/content/repositories/snapshots/io/jaegertracing/).
-Follow these [instructions](http://stackoverflow.com/questions/7715321/how-to-download-snapshot-version-from-maven-snapshot-repository)
-to add the snapshot repository to your build system. 
+All artifacts are published to Maven Central. Snapshot artifacts are also published to [Sonatype][sonatype].
+Follow these [instructions][sonatype-snapshot-instructions] to add the snapshot repository to your build system.
 
-Add the required dependencies to your project. Usually, this would only be the add-ons you require.
 **Please use the latest version:** [![Released Version][maven-img]][maven]
 
-For e.g, to depend on the core jaeger library, you'd include the following
+In the usual case, you just need to include the dependency with the concrete components sending data to the backend. Currently,
+the only such dependency is `jaeger-thrift`. It transitively brings the `jaeger-core` dependency.
 ```xml
 <dependency>
     <groupId>io.jaegertracing</groupId>
-    <artifactId>jaeger-core</artifactId>
+    <artifactId>jaeger-thrift</artifactId>
     <version>$jaegerVersion</version>
 </dependency>
 ```
 
 ### Thrift version conflicts
-Jaeger client uses `org.apache.thrift:libthrift:0.9.2`. If your project depends on a different
-version of `libthrift`, it is recommended that you use the shaded `jaeger-thrift` jar we publish
-which packages it's own `libthrift`.
-
-To depend on the shaded jar, add the following to your maven build.
-Note that this is only supported for a jaeger version >= 0.15.0
-```xml
-<dependencyManagement>
-  <dependencies>
-    <dependency>
-      <groupId>io.jaegertracing</groupId>
-      <artifactId>jaeger-thrift</artifactId>
-      <classifier>thrift92</classifier>
-      <version>$jaegerVersion</version>
-    </dependency>
-  </dependencies>
-</dependencyManagement>
-```
+The Jaeger Java Client uses `org.apache.thrift:libthrift:0.11.0`. By default, declaring a dependency on the
+`jaeger-thrift` module will bring a shaded version of Thrift (and others), making it safe to use your own versions of
+such dependencies. A non-shaded version of the dependency is available with the classifier `no-shadow`, but the
+transitive dependencies (Thrift included) will have to be added manually to your project.
 
 ## Instantiating the Tracer
 
@@ -131,7 +116,6 @@ This allows using Jaeger UI to find the trace by this tag.
 [Apache 2.0 License](./LICENSE).
 
 
-
 [ci-img]: https://travis-ci.org/jaegertracing/jaeger-client-java.svg?branch=master
 [ci]: https://travis-ci.org/jaegertracing/jaeger-client-java
 [cov-img]: https://codecov.io/gh/jaegertracing/jaeger-client-java/branch/master/graph/badge.svg
@@ -140,3 +124,7 @@ This allows using Jaeger UI to find the trace by this tag.
 [maven]: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.jaegertracing%22
 [fossa-img]: https://app.fossa.io/api/projects/git%2Bgithub.com%2Fjaegertracing%2Fjaeger-client-java.svg?type=shield
 [fossa]: https://app.fossa.io/projects/git%2Bgithub.com%2Fjaegertracing%2Fjaeger-client-java?ref=badge_shield
+[sonatype]: https://oss.sonatype.org/content/repositories/snapshots/io/jaegertracing/
+[sonatype-snapshot-instructions]: http://stackoverflow.com/questions/7715321/how-to-download-snapshot-version-from-maven-snapshot-repository
+[tracerresolver]: https://github.com/opentracing-contrib/java-tracerresolver
+[legacy-client-java]: https://github.com/jaegertracing/legacy-client-java

--- a/jaeger-core/README.md
+++ b/jaeger-core/README.md
@@ -10,6 +10,9 @@ This module provides core tracing functionality for custom instrumentation.
 </dependency>
 ```
 
+Note that you'll most likely want to include a higher-level dependency that includes components
+sending data to a backend, like [`io.jaegertracing:jaeger-thrift`](../jaeger-thrift).
+
 ## Usage
 
 ### Production
@@ -20,8 +23,7 @@ For production it is recommended to use both classes with default values.
 `Tracer.Builder` example:
 
 ```java
-Tracer tracer = new Tracer.Builder("myServiceName")
-  .build()
+Tracer tracer = new Tracer.Builder("myServiceName").build()
 ```
 
 `Configuration` holds only primitive values and it is designed to be used with configuration
@@ -37,10 +39,10 @@ Tracer tracer = config.getTracer();
 The `config` objects lazily builds and configures Jaeger Tracer. Multiple calls to `getTracer()` return the same instance.
 
 ##### B3 propagation
-Jaeger tracer can also work in the environment where B3 propagation is used. This is mostly related 
+Jaeger Tracer can also work in the environment where B3 propagation is used. This is mostly related
 to systems instrumented with Zipkin. Once you register `B3TextMapCodec`, Jaeger can join traces 
 started by other Zipkin instrumented applications. This includes reading headers 
-like "X-B3-TraceId". Jaeger B3 implementation automatically propagates baggage and by default it
+like `X-B3-TraceId`. Jaeger B3 implementation automatically propagates baggage and by default it
 uses `baggage-` prefix.
 
 Example configuration:

--- a/jaeger-crossdock/build.gradle
+++ b/jaeger-crossdock/build.gradle
@@ -14,6 +14,9 @@ dependencies {
     compile project(':jaeger-core')
     compile project(':jaeger-thrift')
 
+    compile group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
+    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion
+
     compile group: 'io.opentracing.contrib', name: 'opentracing-jaxrs2', version: '0.1.4'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
     compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: jerseyVersion

--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -5,13 +5,18 @@ description = 'Library to send data to Jaeger backend components via Thrift'
 
 dependencies {
     compile project(':jaeger-core')
-    compile group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
-    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion
+
+    compileOnly group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
+    compileOnly group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion
 
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'com.tngtech.java', name: 'junit-dataprovider', version: junitDataProviderVersion
     testCompile group: 'org.awaitility', name: 'awaitility', version: awaitilityVersion
     testCompile group: 'org.glassfish.jersey.test-framework.providers', name: 'jersey-test-framework-provider-grizzly2', version: jerseyVersion
+
+    // compileOnly dependencies aren't visible to tests
+    testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion
+    testCompile group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
 
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 }
@@ -40,6 +45,10 @@ licenseMain.enabled = false
 checkstyleMain.enabled = false
 checkstyleTest.enabled = false
 
+jar {
+    classifier 'no-shadow'
+}
+
 shadowJar {
     baseName = 'jaeger-thrift'
     relocate 'com.google.gson'  , 'jaeger.com.google.gson'
@@ -47,7 +56,8 @@ shadowJar {
     relocate 'okhttp'           , 'jaeger.okhttp'
     relocate 'okio'             , 'jaeger.okio'
     relocate 'org.apache'       , 'jaeger.org.apache'
-    classifier 'shadow'
+    classifier null
+    configurations = [project.configurations.compileOnly]
 }
 
 task testJar(type: Jar, dependsOn: testClasses) {

--- a/jaeger-zipkin/build.gradle
+++ b/jaeger-zipkin/build.gradle
@@ -7,6 +7,8 @@ dependencies {
     compile group: 'io.zipkin.java', name: 'zipkin', version: '2.8.1'
     compile group: 'io.zipkin.reporter2', name: 'zipkin-reporter', version: '2.6.0'
 
+    compile group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
+
     compile project(':jaeger-core')
     compile project(':jaeger-thrift')
 


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- Resolves #460 

## Short description of the changes
- Changed classifiers for both the `jar` task and `shadowJar`
- Changed shadowed dependencies to `compileOnly` so that depending projects won't transitively depend on Thrift and OkHttp.
- Changed the README to be accurate with the current situation (plus some minor improvements)

A project depending on `jaeger-thrift` with this change will have this automatically pulled:

```
[INFO] +- io.jaegertracing:jaeger-thrift:jar:0.29.1-SNAPSHOT:compile
[INFO] |  \- io.jaegertracing:jaeger-core:jar:0.29.1-SNAPSHOT:compile
[INFO] |     +- io.opentracing:opentracing-api:jar:0.31.0:compile
[INFO] |     +- io.opentracing:opentracing-util:jar:0.31.0:compile
[INFO] |     +- com.google.code.gson:gson:jar:2.8.2:compile
[INFO] |     \- org.slf4j:slf4j-api:jar:1.7.25:compile
```

And without this change:

```
[INFO] +- io.jaegertracing:jaeger-thrift:jar:0.29.1-SNAPSHOT:compile
[INFO] |  +- io.jaegertracing:jaeger-core:jar:0.29.1-SNAPSHOT:compile
[INFO] |  |  +- io.opentracing:opentracing-api:jar:0.31.0:compile
[INFO] |  |  +- io.opentracing:opentracing-util:jar:0.31.0:compile
[INFO] |  |  +- com.google.code.gson:gson:jar:2.8.2:compile
[INFO] |  |  \- org.slf4j:slf4j-api:jar:1.7.25:compile
[INFO] |  +- org.apache.thrift:libthrift:jar:0.11.0:compile
[INFO] |  |  +- org.apache.httpcomponents:httpclient:jar:4.5.3:compile
[INFO] |  |  |  \- commons-codec:commons-codec:jar:1.10:compile
[INFO] |  |  \- org.apache.httpcomponents:httpcore:jar:4.4.8:compile
[INFO] |  \- com.squareup.okhttp3:okhttp:jar:3.9.0:compile
[INFO] |     \- com.squareup.okio:okio:jar:1.13.0:compile
```