### PR TITLE
Fix bug described in (#459)

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/metrics/InMemoryMetricsFactory.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/metrics/InMemoryMetricsFactory.java
@@ -62,7 +62,7 @@ public class InMemoryMetricsFactory implements MetricsFactory {
     return new Gauge() {
       @Override
       public void update(long amount) {
-        value.addAndGet(amount);
+        value.getAndSet(amount);
       }
     };
   }

--- a/jaeger-core/src/test/java/io/jaegertracing/metrics/InMemoryMetricsFactoryTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/metrics/InMemoryMetricsFactoryTest.java
@@ -85,7 +85,7 @@ public class InMemoryMetricsFactoryTest {
   }
 
   @Test
-  public void gaugeValueIsIncreased() {
+  public void gaugeValueIsUpdated() {
     Map<String, String> tags = Collections.singletonMap("foo", "bar");
 
     InMemoryMetricsFactory inMemoryMetricsFactory = new InMemoryMetricsFactory();
@@ -93,8 +93,10 @@ public class InMemoryMetricsFactoryTest {
     assertEquals(0, inMemoryMetricsFactory.getGauge("thegauge", tags));
 
     gauge.update(1);
-
     assertEquals(1, inMemoryMetricsFactory.getGauge("thegauge", tags));
+
+    gauge.update(2);
+    assertEquals(2, inMemoryMetricsFactory.getGauge("thegauge", tags));
   }
 
   @Test


### PR DESCRIPTION
### Which problem is this PR solving?
InMemoryMetricsFactory gauge wrongly update its value.
The behavior is described in (#459)

### Description of the change
In InMemoryMetricsFactory, upon updating the gauge, the argument
should be considered as the new value and not a variation to
the previous one.

Signed-off-by: Mehrez Douaihy <mehrez.douaihy@gmail.com>

