### PR TITLE
After finish, disallow setTag.

### DIFF
--- a/jaeger-core/build.gradle
+++ b/jaeger-core/build.gradle
@@ -13,8 +13,8 @@ dependencies {
     testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
     testCompile group: 'com.tngtech.java', name: 'junit-dataprovider', version: junitDataProviderVersion
     testCompile group: 'org.awaitility', name: 'awaitility', version: awaitilityVersion
-    testCompile group: 'ch.qos.logback', name: 'logback-classic', version: logbackVersion
     testCompile group: 'io.micrometer', name: 'micrometer-registry-prometheus', version: micrometerVersion
+    testCompile group: 'uk.org.lidalia', name: 'slf4j-test', version: '1.2.0'
 
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 }

--- a/jaeger-core/src/main/java/io/jaegertracing/JaegerTracer.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/JaegerTracer.java
@@ -226,7 +226,7 @@ public class JaegerTracer implements Tracer, Closeable {
     private final Map<String, Object> tags = new HashMap<String, Object>();
     private boolean ignoreActiveSpan = false;
 
-    SpanBuilder(String operationName) {
+    private SpanBuilder(String operationName) {
       this.operationName = operationName;
     }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
If you set the tag after the span finishes, this can cause a race condition in the sender as it tries to iterate over the tag map.

To fix that, you really shouldn't even be able to set a tag after the span finishes.
## Short description of the changes
Check finish on setTagAsObject and return if the span is already finished.
