### PR TITLE
Change return types from Jaeger Span/Tracer/Context to Jaeger types

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
@@ -218,7 +218,7 @@ public class Configuration {
     return builder;
   }
 
-  public synchronized Tracer getTracer() {
+  public synchronized JaegerTracer getTracer() {
     if (tracer != null) {
       return tracer;
     }

--- a/jaeger-core/src/main/java/io/jaegertracing/JaegerSpanContext.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/JaegerSpanContext.java
@@ -119,7 +119,7 @@ public class JaegerSpanContext implements SpanContext {
     }
 
     /*
-      TODO(oibe) because java doesn't like to convert large hex strings to longs
+      oibe: because java doesn't like to convert large hex strings to longs
       we should write this manually instead of using BigInteger.
     */
     return new JaegerSpanContext(

--- a/jaeger-core/src/test/java/io/jaegertracing/JaegerTracerResiliencyTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/JaegerTracerResiliencyTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.assertNull;
 import io.jaegertracing.propagation.Codec;
 import io.jaegertracing.reporters.InMemoryReporter;
 import io.jaegertracing.samplers.ConstSampler;
-import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format.Builtin;
 import io.opentracing.propagation.TextMap;
 import java.util.Iterator;
@@ -43,13 +42,13 @@ public class JaegerTracerResiliencyTest {
 
   @Test
   public void shouldFallbackWhenExtractingWithFaultyCodec() {
-    SpanContext span = tracer.extract(Builtin.TEXT_MAP, new NoopTextMap());
+    JaegerSpanContext span = tracer.extract(Builtin.TEXT_MAP, new NoopTextMap());
     assertNull(span);
   }
 
   @Test
   public void shouldFallbackWhenInjectingWithFaultyCodec() {
-    SpanContext context = tracer.buildSpan("test-span").start().context();
+    JaegerSpanContext context = tracer.buildSpan("test-span").start().context();
     tracer.inject(context, Builtin.TEXT_MAP, new NoopTextMap());
   }
 

--- a/jaeger-core/src/test/java/io/jaegertracing/JaegerTracerTagsTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/JaegerTracerTagsTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class JaegerTracerTagsTest {
 
   @Test
-  public void testTracerTags() throws Exception {
+  public void testTracerTags() {
     InMemoryReporter spanReporter = new InMemoryReporter();
     JaegerTracer tracer = new JaegerTracer.Builder("x")
         .withReporter(spanReporter)
@@ -35,7 +35,7 @@ public class JaegerTracerTagsTest {
         .withTag("tracer.tag.str", "y")
         .build();
 
-    JaegerSpan jaegerSpan = (JaegerSpan) tracer.buildSpan("root").start();
+    JaegerSpan jaegerSpan = tracer.buildSpan("root").start();
 
     // span should only contain sampler tags and no tracer tags
     assertEquals(2, jaegerSpan.getTags().size());
@@ -56,7 +56,7 @@ public class JaegerTracerTagsTest {
   }
 
   @Test
-  public void testDeclaredHostTags() throws Exception {
+  public void testDeclaredHostTags() {
     InMemoryReporter spanReporter = new InMemoryReporter();
     String hostname = "myhost";
     String ip = "1.1.1.1";
@@ -71,7 +71,7 @@ public class JaegerTracerTagsTest {
   }
 
   @Test
-  public void testEmptyDeclaredIpTag() throws Exception {
+  public void testEmptyDeclaredIpTag() {
     InMemoryReporter spanReporter = new InMemoryReporter();
     String ip = "";
     JaegerTracer tracer = new JaegerTracer.Builder("x")
@@ -82,7 +82,7 @@ public class JaegerTracerTagsTest {
   }
 
   @Test
-  public void testShortDeclaredIpTag() throws Exception {
+  public void testShortDeclaredIpTag() {
     InMemoryReporter spanReporter = new InMemoryReporter();
     String ip = ":19";
     JaegerTracer tracer = new JaegerTracer.Builder("x")

--- a/jaeger-core/src/test/java/io/jaegertracing/propagation/B3TextMapCodecResiliencyTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/propagation/B3TextMapCodecResiliencyTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertNull;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
-import io.opentracing.SpanContext;
+import io.jaegertracing.JaegerSpanContext;
 import io.opentracing.propagation.TextMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,7 +50,7 @@ public class B3TextMapCodecResiliencyTest {
     TextMap maliciousCarrier = validHeaders();
     maliciousCarrier.put(headerName, maliciousInput);
     //when
-    SpanContext extract = sut.extract(maliciousCarrier);
+    JaegerSpanContext extract = sut.extract(maliciousCarrier);
     //then
     assertNull(extract);
   }

--- a/jaeger-core/src/test/java/io/jaegertracing/propagation/B3TextMapCodecTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/propagation/B3TextMapCodecTest.java
@@ -39,7 +39,7 @@ public class B3TextMapCodecTest {
   B3TextMapCodec b3Codec = new B3TextMapCodec.Builder().build();
 
   @Test
-  public void downgrades128BitTraceIdToLower64Bits() throws Exception {
+  public void downgrades128BitTraceIdToLower64Bits() {
     String hex128Bits = "463ac35c9f6413ad48485a3953bb6124";
     String lower64Bits = "48485a3953bb6124";
 
@@ -52,7 +52,7 @@ public class B3TextMapCodecTest {
     textMap.put(B3TextMapCodec.BAGGAGE_PREFIX + "foo", "bar");
     textMap.put("random-foo", "bar");
 
-    JaegerSpanContext context = (JaegerSpanContext) b3Codec.extract(textMap);
+    JaegerSpanContext context = b3Codec.extract(textMap);
 
     assertNotNull(HexCodec.lowerHexToUnsignedLong(lower64Bits));
     assertEquals(HexCodec.lowerHexToUnsignedLong(lower64Bits).longValue(), context.getTraceId());
@@ -97,7 +97,7 @@ public class B3TextMapCodecTest {
   }
 
   @Test
-  public void testInject() throws Exception {
+  public void testInject() {
     DelegatingTextMap textMap = new DelegatingTextMap();
     b3Codec.inject(new JaegerSpanContext(1, 1, 1, SAMPLED), textMap);
 

--- a/jaeger-core/src/test/java/io/jaegertracing/reporters/RemoteReporterTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/reporters/RemoteReporterTest.java
@@ -50,7 +50,7 @@ public class RemoteReporterTest {
   private InMemoryMetricsFactory metricsFactory;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     metricsFactory = new InMemoryMetricsFactory();
     metrics = new Metrics(metricsFactory);
 
@@ -69,8 +69,8 @@ public class RemoteReporterTest {
   }
 
   @Test
-  public void testRemoteReporterReport() throws Exception {
-    JaegerSpan span = (JaegerSpan) tracer.buildSpan("raza").start();
+  public void testRemoteReporterReport() {
+    JaegerSpan span = tracer.buildSpan("raza").start();
     reporter.report(span);
     // do sleep until automatic flush happens on 'reporter'
     // added 20ms on top of 'flushInterval' to avoid corner cases
@@ -85,10 +85,10 @@ public class RemoteReporterTest {
   }
 
   @Test
-  public void testRemoteReporterFlushesOnClose() throws Exception {
+  public void testRemoteReporterFlushesOnClose() {
     int numberOfSpans = 100;
     for (int i = 0; i < numberOfSpans; i++) {
-      JaegerSpan span = (JaegerSpan) tracer.buildSpan("raza").start();
+      JaegerSpan span = tracer.buildSpan("raza").start();
       reporter.report(span);
     }
     reporter.close();
@@ -102,7 +102,7 @@ public class RemoteReporterTest {
   }
 
   @Test
-  public void testRemoteReporterFlushTimerThread() throws Exception {
+  public void testRemoteReporterFlushTimerThread() {
     int flushTimerThreadCount = 0;
     for (Thread thread : Thread.getAllStackTraces().keySet()) {
       if (!thread.getName().equals("jaeger.RemoteReporter-FlushTimer")) {
@@ -218,7 +218,7 @@ public class RemoteReporterTest {
   }
 
   @Test
-  public void testFlushUpdatesQueueLength() throws Exception {
+  public void testFlushUpdatesQueueLength() {
     int neverFlushInterval = Integer.MAX_VALUE;
     reporter = new RemoteReporter.Builder()
         .withSender(sender)
@@ -275,10 +275,10 @@ public class RemoteReporterTest {
     remoteReporter.flush();
     latch.await();
     assertEquals("Should have called the custom sender flush", 0, latch.getCount());
-    assertEquals("mySpan", ((JaegerSpan) sender.getReceived().get(0)).getOperationName());
+    assertEquals("mySpan", (sender.getReceived().get(0)).getOperationName());
   }
 
   private JaegerSpan newSpan() {
-    return (JaegerSpan) tracer.buildSpan("x").start();
+    return tracer.buildSpan("x").start();
   }
 }

--- a/jaeger-crossdock/src/main/java/io/jaegertracing/crossdock/resources/behavior/TraceBehavior.java
+++ b/jaeger-crossdock/src/main/java/io/jaegertracing/crossdock/resources/behavior/TraceBehavior.java
@@ -93,7 +93,7 @@ public class TraceBehavior {
       return new ObservedSpan("no span found", false, "no span found");
     }
 
-    JaegerSpanContext context = (JaegerSpanContext) span.context();
+    JaegerSpanContext context = span.context();
     String traceId = String.format("%x", context.getTraceId());
     boolean sampled = context.isSampled();
     String baggage = span.getBaggageItem(Constants.BAGGAGE_KEY);

--- a/jaeger-micrometer/src/test/java/io/jaegertracing/micrometer/MicrometerTest.java
+++ b/jaeger-micrometer/src/test/java/io/jaegertracing/micrometer/MicrometerTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import io.jaegertracing.Configuration;
+import io.jaegertracing.JaegerSpan;
 import io.jaegertracing.JaegerTracer;
 import io.jaegertracing.metrics.Metrics;
 import io.jaegertracing.metrics.Timer;
@@ -30,14 +31,11 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
-import io.opentracing.Span;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
 import org.hamcrest.core.IsEqual;
 import org.junit.After;
 import org.junit.Before;
@@ -211,7 +209,7 @@ public class MicrometerTest {
 
   private void createSomeSpans(JaegerTracer tracer) {
     for (int i = 0; i < 10; i++) {
-      Span span = tracer.buildSpan("metricstest")
+      JaegerSpan span = tracer.buildSpan("metricstest")
               .withTag("foo", "bar" + i)
               .start();
       // Only finish every 3rd span so jaeger:started_spans and finished_spans counts are different

--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/reporters/protocols/JaegerThriftSpanConverter.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/reporters/protocols/JaegerThriftSpanConverter.java
@@ -34,7 +34,7 @@ public class JaegerThriftSpanConverter {
   private JaegerThriftSpanConverter() {}
 
   public static io.jaegertracing.thriftjava.Span convertSpan(JaegerSpan jaegerSpan) {
-    JaegerSpanContext context = (JaegerSpanContext) jaegerSpan.context();
+    JaegerSpanContext context = jaegerSpan.context();
 
     boolean oneChildOfParent = jaegerSpan.getReferences().size() == 1
         && References.CHILD_OF.equals(jaegerSpan.getReferences().get(0).getType());

--- a/jaeger-thrift/src/test/java/io/jaegertracing/thrift/senders/UdpSenderTest.java
+++ b/jaeger-thrift/src/test/java/io/jaegertracing/thrift/senders/UdpSenderTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import io.jaegertracing.JaegerSpan;
-import io.jaegertracing.JaegerSpanContext;
 import io.jaegertracing.JaegerTracer;
 import io.jaegertracing.exceptions.SenderException;
 import io.jaegertracing.metrics.InMemoryMetricsFactory;
@@ -86,7 +85,7 @@ public class UdpSenderTest {
 
   @Test(expected = SenderException.class)
   public void testAppendSpanTooLarge() throws Exception {
-    JaegerSpan jaegerSpan = (JaegerSpan) tracer.buildSpan("raza").start();
+    JaegerSpan jaegerSpan = tracer.buildSpan("raza").start();
     String msg = "";
     for (int i = 0; i < 10001; i++) {
       msg += ".";
@@ -104,8 +103,8 @@ public class UdpSenderTest {
   @Test
   public void testAppend() throws Exception {
     // find size of the initial span
-    JaegerSpan jaegerSpan = (JaegerSpan) tracer.buildSpan("raza").start();
-    io.jaegertracing.thriftjava.Span span = JaegerThriftSpanConverter.convertSpan((JaegerSpan) jaegerSpan);
+    JaegerSpan jaegerSpan = tracer.buildSpan("raza").start();
+    io.jaegertracing.thriftjava.Span span = JaegerThriftSpanConverter.convertSpan(jaegerSpan);
 
     Process process = new Process(tracer.getServiceName())
         .setTags(JaegerThriftSpanConverter.buildTags(tracer.tags()));
@@ -135,7 +134,7 @@ public class UdpSenderTest {
   public void testFlushSendsSpan() throws Exception {
     int timeout = 50; // in milliseconds
     int expectedNumSpans = 1;
-    JaegerSpan expectedSpan = (JaegerSpan) tracer.buildSpan("raza").start();
+    JaegerSpan expectedSpan = tracer.buildSpan("raza").start();
     int appendNum = sender.append(expectedSpan);
     int flushNum = sender.flush();
     assertEquals(appendNum, 0);
@@ -145,9 +144,9 @@ public class UdpSenderTest {
     assertEquals(expectedNumSpans, batch.getSpans().size());
 
     io.jaegertracing.thriftjava.Span actualSpan = batch.getSpans().get(0);
-    assertEquals(((JaegerSpanContext) expectedSpan.context()).getTraceId(), actualSpan.getTraceIdLow());
+    assertEquals(expectedSpan.context().getTraceId(), actualSpan.getTraceIdLow());
     assertEquals(0, actualSpan.getTraceIdHigh());
-    assertEquals(((JaegerSpanContext) expectedSpan.context()).getSpanId(), actualSpan.getSpanId());
+    assertEquals(expectedSpan.context().getSpanId(), actualSpan.getSpanId());
     assertEquals(0, actualSpan.getParentSpanId());
     assertTrue(actualSpan.references.isEmpty());
     assertEquals(expectedSpan.getOperationName(), actualSpan.getOperationName());

--- a/jaeger-tracerresolver/src/main/java/io/jaegertracing/tracerresolver/JaegerTracerResolver.java
+++ b/jaeger-tracerresolver/src/main/java/io/jaegertracing/tracerresolver/JaegerTracerResolver.java
@@ -15,13 +15,13 @@
 package io.jaegertracing.tracerresolver;
 
 import io.jaegertracing.Configuration;
-import io.opentracing.Tracer;
+import io.jaegertracing.JaegerTracer;
 import io.opentracing.contrib.tracerresolver.TracerResolver;
 
 public class JaegerTracerResolver extends TracerResolver {
 
   @Override
-  protected Tracer resolve() {
+  protected JaegerTracer resolve() {
     return Configuration.fromEnv().getTracer();
   }
 

--- a/jaeger-zipkin/src/main/java/io/jaegertracing/senders/zipkin/ThriftSpanConverter.java
+++ b/jaeger-zipkin/src/main/java/io/jaegertracing/senders/zipkin/ThriftSpanConverter.java
@@ -41,7 +41,7 @@ public class ThriftSpanConverter {
     JaegerTracer tracer = jaegerSpan.getTracer();
     Endpoint host = new Endpoint(tracer.getIpv4(), (short) 0, tracer.getServiceName());
 
-    JaegerSpanContext context = (JaegerSpanContext) jaegerSpan.context();
+    JaegerSpanContext context = jaegerSpan.context();
     return new com.twitter.zipkin.thriftjava.Span(
             context.getTraceId(),
             jaegerSpan.getOperationName(),

--- a/jaeger-zipkin/src/main/java/io/jaegertracing/senders/zipkin/ZipkinSender.java
+++ b/jaeger-zipkin/src/main/java/io/jaegertracing/senders/zipkin/ZipkinSender.java
@@ -112,7 +112,7 @@ public final class ZipkinSender implements Sender {
    */
   @Override
   public int append(JaegerSpan span) throws SenderException {
-    byte[] next = encoder.encode(backFillHostOnAnnotations(ThriftSpanConverter.convertSpan((JaegerSpan) span)));
+    byte[] next = encoder.encode(backFillHostOnAnnotations(ThriftSpanConverter.convertSpan(span)));
     int messageSizeOfNextSpan = delegate.messageSizeInBytes(Collections.singletonList(next));
     // don't enqueue something larger than we can drain
     if (messageSizeOfNextSpan > delegate.messageMaxBytes()) {

--- a/jaeger-zipkin/src/main/java/io/jaegertracing/zipkin/V2SpanConverter.java
+++ b/jaeger-zipkin/src/main/java/io/jaegertracing/zipkin/V2SpanConverter.java
@@ -42,7 +42,7 @@ public class V2SpanConverter {
 
     zipkin2.Endpoint peerEndpoint = extractPeerEndpoint(span.getTags());
 
-    JaegerSpanContext context = (JaegerSpanContext) span.context();
+    JaegerSpanContext context = span.context();
     zipkin2.Span.Builder builder = zipkin2.Span.newBuilder()
             .id(Long.toHexString(context.getSpanId()))
             .traceId(Long.toHexString(context.getTraceId()))

--- a/jaeger-zipkin/src/test/java/io/jaegertracing/senders/zipkin/ZipkinSenderTest.java
+++ b/jaeger-zipkin/src/test/java/io/jaegertracing/senders/zipkin/ZipkinSenderTest.java
@@ -78,7 +78,7 @@ public class ZipkinSenderTest {
 
   @Test
   public void testAppendSpanTooLarge() {
-    JaegerSpan jaegerSpan = (JaegerSpan) tracer.buildSpan("raza").start();
+    JaegerSpan jaegerSpan = tracer.buildSpan("raza").start();
     String msg = "";
     for (int i = 0; i < 1001; i++) {
       msg += ".";
@@ -95,7 +95,7 @@ public class ZipkinSenderTest {
 
   @Test
   public void testAppend() throws Exception {
-    JaegerSpan jaegerSpan = (JaegerSpan) tracer.buildSpan("raza").start();
+    JaegerSpan jaegerSpan = tracer.buildSpan("raza").start();
     com.twitter.zipkin.thriftjava.Span span = ThriftSpanConverter.convertSpan(jaegerSpan);
 
     int expectedNumSpans = 11;
@@ -104,7 +104,7 @@ public class ZipkinSenderTest {
       spansToSend.add(new ThriftSpanEncoder().encode(ZipkinSender.backFillHostOnAnnotations(span)));
     }
 
-    // create a sender thats a multiple of the span size (accounting for span overhead)
+    // create a sender that's a multiple of the span size (accounting for span overhead)
     // this allows us to test the boundary conditions of writing spans.
     int messageMaxBytes = sender.delegate.messageSizeInBytes(spansToSend);
     sender.close();
@@ -122,7 +122,7 @@ public class ZipkinSenderTest {
 
   @Test
   public void testFlushSendsSpan() throws Exception {
-    JaegerSpan expectedSpan = (JaegerSpan) tracer.buildSpan("raza").start();
+    JaegerSpan expectedSpan = tracer.buildSpan("raza").start();
 
     assertEquals(0, sender.append(expectedSpan));
     assertEquals(1, sender.flush());
@@ -132,7 +132,7 @@ public class ZipkinSenderTest {
     assertEquals(traces.get(0).size(), 1);
 
     zipkin2.Span actualSpan = traces.get(0).get(0);
-    JaegerSpanContext context = (JaegerSpanContext) expectedSpan.context();
+    JaegerSpanContext context = expectedSpan.context();
 
     assertEquals(context.getTraceId(), HexCodec.lowerHexToUnsignedLong(actualSpan.traceId()));
     assertEquals(context.getSpanId(), HexCodec.lowerHexToUnsignedLong(actualSpan.id()));
@@ -144,7 +144,7 @@ public class ZipkinSenderTest {
 
   @Test
   public void testAppendSpanWithLogs() throws Exception {
-    JaegerSpan jaegerSpan = (JaegerSpan) tracer.buildSpan("jaegerSpan-with-logs").start();
+    JaegerSpan jaegerSpan = tracer.buildSpan("jaegerSpan-with-logs").start();
 
     jaegerSpan.log("event");
 

--- a/jaeger-zipkin/src/test/java/io/jaegertracing/zipkin/reporters/ZipkinV2ReporterTest.java
+++ b/jaeger-zipkin/src/test/java/io/jaegertracing/zipkin/reporters/ZipkinV2ReporterTest.java
@@ -41,7 +41,7 @@ public class ZipkinV2ReporterTest {
   JaegerTracer tracer;
 
   @Before
-  public void setup() throws Exception {
+  public void setup() {
     sender = URLConnectionSender.newBuilder()
         .encoding(Encoding.JSON)
         .endpoint(zipkinRule.httpUrl() + "/api/v2/spans")
@@ -61,8 +61,8 @@ public class ZipkinV2ReporterTest {
   }
 
   @Test
-  public void testConvertsAndSendsSpan() throws Exception {
-    JaegerSpan span = (JaegerSpan) tracer.buildSpan("raza").start();
+  public void testConvertsAndSendsSpan() {
+    JaegerSpan span = tracer.buildSpan("raza").start();
     span.finish();
 
     reporter.report(span);


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- Resolves #468

## Short description of the changes
- Where it was previously returning OpenTracing types, we are now returning Jaeger types.
- Changed the tests to use the Jaeger types, to signal that those are the types we expect the methods to return and to avoid casts
