### PR TITLE
Fix version retrieval from jaeger.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 gen-java/
-jaeger-core/src/main/resources/io/jaegertracing/jaeger.properties
+jaeger-core/src/main/resources/io/jaegertracing/internal/jaeger.properties
 
 ### Eclipse ###
 

--- a/jaeger-core/build.gradle
+++ b/jaeger-core/build.gradle
@@ -30,7 +30,7 @@ configurations {
 
 task jaegerVersion {
     doLast {
-        def dirPath = 'src/main/resources/io/jaegertracing/'
+        def dirPath = 'src/main/resources/io/jaegertracing/internal/'
         new File(projectDir, dirPath).mkdirs()
         def propFile = new File(projectDir, "${dirPath}jaeger.properties").getAbsolutePath()
         new File(propFile).write("jaeger.version=${project.version}")

--- a/jaeger-core/src/main/resources/io/jaegertracing/internal/jaeger.properties
+++ b/jaeger-core/src/main/resources/io/jaegertracing/internal/jaeger.properties
@@ -1,1 +1,0 @@
-jaeger.version=0.29.1-SNAPSHOT


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- Resolves #477 

## Short description of the changes
- Removed `jaeger.properties` and fixed path to it, as it's now under `internal`

After this patch is applied, this is the expected output from the Jaeger tracer:

```
2018-07-05 16:15:11.355  INFO 27873 --- [ost-startStop-1] io.jaegertracing.Configuration           : Initialized tracer=JaegerTracer(version=Java-0.30.1-SNAPSHOT, serviceName=customer, reporter=CompositeReporter(reporters=[RemoteReporter(queueProcessor=RemoteReporter.QueueProcessor(open=true), sender=UdpSender(udpTransport=ThriftUdpTransport(socket=java.net.DatagramSocket@3ce7f19e, receiveBuf=null, receiveOffSet=-1, receiveLength=0)), closeEnqueueTimeout=1000), LoggingReporter(logger=Logger[io.jaegertracing.internal.reporters.LoggingReporter])]), sampler=ConstSampler(decision=true, tags={sampler.type=const, sampler.param=true}), ipv4=-1062686141, tags={hostname=caju.kroehling.de, jaeger.version=Java-0.30.1-SNAPSHOT, ip=192.168.178.67}, zipkinSharedRpcSpan=false, baggageSetter=io.jaegertracing.internal.baggage.BaggageSetter@775b0f05, expandExceptionLogs=false)
```
