### PR TITLE
Specify custom sender for tests in the module jaeger-client

### DIFF
--- a/jaeger-client/build.gradle
+++ b/jaeger-client/build.gradle
@@ -10,6 +10,4 @@ dependencies {
     compile project(':jaeger-tracerresolver')
 
     testCompile group: 'junit', name: 'junit', version: junitVersion
-    testCompile group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
-    testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion
 }

--- a/jaeger-client/src/test/java/io/jaegertracing/client/VersionTest.java
+++ b/jaeger-client/src/test/java/io/jaegertracing/client/VersionTest.java
@@ -19,9 +19,22 @@ import static org.junit.Assert.assertNotEquals;
 
 import io.jaegertracing.Configuration;
 import io.jaegertracing.internal.JaegerTracer;
+import io.jaegertracing.internal.senders.NoopSender;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public class VersionTest {
+
+  @Before
+  public void setEnvironment() {
+    System.setProperty(Configuration.JAEGER_SENDER_FACTORY, NoopSender.class.getName());
+  }
+
+  @After
+  public void unsetEnvironment() {
+    System.clearProperty(Configuration.JAEGER_SENDER_FACTORY);
+  }
 
   @Test
   public void testVersionGet() {

--- a/jaeger-client/src/test/resources/META-INF/services/io.jaegertracing.spi.SenderFactory
+++ b/jaeger-client/src/test/resources/META-INF/services/io.jaegertracing.spi.SenderFactory
@@ -1,0 +1,1 @@
+io.jaegertracing.internal.senders.NoopSenderFactory

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/senders/NoopSenderFactory.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/senders/NoopSenderFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018, The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.jaegertracing.internal.senders;
+
+import io.jaegertracing.Configuration;
+import io.jaegertracing.internal.senders.NoopSender;
+import io.jaegertracing.spi.Sender;
+import io.jaegertracing.spi.SenderFactory;
+
+public class NoopSenderFactory implements SenderFactory {
+  @Override
+  public Sender getSender(Configuration.SenderConfiguration senderConfiguration) {
+    return new NoopSender();
+  }
+
+  @Override
+  public String getType() {
+    return "noop";
+  }
+}

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/senders/SenderResolver.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/senders/SenderResolver.java
@@ -55,7 +55,7 @@ public class SenderResolver {
     Iterator<SenderFactory> senderFactoryIterator = senderFactoryServiceLoader.iterator();
 
     boolean hasMultipleFactories = false;
-    if (senderFactoryIterator.hasNext()) {
+    while (senderFactoryIterator.hasNext()) {
       SenderFactory senderFactory = senderFactoryIterator.next();
 
       if (senderFactoryIterator.hasNext()) {


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- Currently, the tests in the `jaeger-client` module depend on Thrift and OkHttp to work, as it's transitively needed by the jaeger-thrift senders. This PR solves that by implementing a custom sender.

## Short description of the changes
- Removed `testCompile` dependencies on `org.apache.thrift:libthrift` and `com.squareup.okhttp3:okhttp`
- Implemented a simple `NoopSenderFactory`, that returns a `NoopSender`.
