### PR TITLE
Fix jaeger-client dependency jaeger-thrift no-shadow artifact

### DIFF
--- a/jaeger-client/build.gradle
+++ b/jaeger-client/build.gradle
@@ -1,12 +1,9 @@
 description = 'Convenience module to be used by instrumented applications'
 
 dependencies {
-    // otherwise, we get the non-shaded version, which will fail at runtime due to missing classes
-    compile group: 'io.jaegertracing', name: 'jaeger-thrift', version: developmentVersion
-
     // for the other projects, we can add the dependency on the projects themselves
+    compile project(path: ':jaeger-thrift', configuration: "shadow")
     compile project(':jaeger-core')
-    compile project(':jaeger-thrift')
     compile project(':jaeger-tracerresolver')
 
     testCompile group: 'junit', name: 'junit', version: junitVersion

--- a/jaeger-client/src/test/java/io/jaegertracing/client/VersionTest.java
+++ b/jaeger-client/src/test/java/io/jaegertracing/client/VersionTest.java
@@ -19,23 +19,9 @@ import static org.junit.Assert.assertNotEquals;
 
 import io.jaegertracing.Configuration;
 import io.jaegertracing.internal.JaegerTracer;
-import io.jaegertracing.internal.senders.NoopSender;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class VersionTest {
-
-  @Before
-  public void setEnvironment() {
-    System.setProperty(Configuration.JAEGER_SENDER_FACTORY, NoopSender.class.getName());
-  }
-
-  @After
-  public void unsetEnvironment() {
-    System.clearProperty(Configuration.JAEGER_SENDER_FACTORY);
-  }
-
   @Test
   public void testVersionGet() {
     assertEquals(

--- a/jaeger-crossdock/build.gradle
+++ b/jaeger-crossdock/build.gradle
@@ -11,8 +11,7 @@ compileJava {
 }
 
 dependencies {
-    compile project(':jaeger-core')
-    compile project(':jaeger-thrift')
+    compile project(':jaeger-client')
 
     compile group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
     compile group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion

--- a/jaeger-zipkin/build.gradle
+++ b/jaeger-zipkin/build.gradle
@@ -1,11 +1,13 @@
 description = 'Integration library for Zipkin'
 
 dependencies {
+    compile project(':jaeger-client')
+
+    // For some reason, we need to use the default configuration here to get access to the Thrift-generated classes
+    compile project(path: ':jaeger-thrift', configuration: "default")
+
     compile group: 'io.zipkin.reporter2', name: 'zipkin-sender-urlconnection', version: '2.7.6'
     compile group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
-
-    compile project(':jaeger-core')
-    compile project(':jaeger-thrift')
 
     testCompile group: 'io.zipkin.zipkin2', name: 'zipkin-junit', version: '2.9.4'
     testCompile group: 'com.tngtech.java', name: 'junit-dataprovider', version: junitDataProviderVersion


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- See https://github.com/objectiser/opentracing-prometheus-example/pull/53

Basically, when using the `jaeger-client`, there's a runtime exception like:

```
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [io.opentracing.Tracer]: Factory method 'getTracer' threw exception; nested exception is java.lang.NoClassDefFoundError: org/apache/thrift/protocol/TProtocolFactory
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:189) ~[spring-beans-4.3.12.RELEASE.jar:4.3.12.RELEASE]
	at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:588) ~[spring-beans-4.3.12.RELEASE.jar:4.3.12.RELEASE]
	... 39 common frames omitted
Caused by: java.lang.NoClassDefFoundError: org/apache/thrift/protocol/TProtocolFactory
	at io.jaegertracing.thrift.internal.senders.ThriftSenderFactory.getSender(ThriftSenderFactory.java:34) ~[jaeger-thrift-0.30.1-no-shadow.jar:0.30.1]
	at io.jaegertracing.internal.senders.SenderResolver.getSenderFromFactory(SenderResolver.java:96) ~[jaeger-core-0.30.1.jar:0.30.1]
	at io.jaegertracing.internal.senders.SenderResolver.resolve(SenderResolver.java:80) ~[jaeger-core-0.30.1.jar:0.30.1]
	at io.jaegertracing.Configuration$SenderConfiguration.getSender(Configuration.java:630) ~[jaeger-core-0.30.1.jar:0.30.1]
	at io.jaegertracing.Configuration$ReporterConfiguration.getReporter(Configuration.java:516) ~[jaeger-core-0.30.1.jar:0.30.1]
	at io.jaegertracing.Configuration$ReporterConfiguration.access$000(Configuration.java:476) ~[jaeger-core-0.30.1.jar:0.30.1]
	at io.jaegertracing.Configuration.getTracerBuilder(Configuration.java:210) ~[jaeger-core-0.30.1.jar:0.30.1]
	at io.jaegertracing.Configuration.getTracer(Configuration.java:226) ~[jaeger-core-0.30.1.jar:0.30.1]
	at io.jaegertracing.tracerresolver.internal.JaegerTracerResolver.resolve(JaegerTracerResolver.java:25) ~[jaeger-tracerresolver-0.30.1.jar:0.30.1]
	at io.jaegertracing.tracerresolver.internal.JaegerTracerResolver.resolve(JaegerTracerResolver.java:21) ~[jaeger-tracerresolver-0.30.1.jar:0.30.1]
	at io.opentracing.contrib.tracerresolver.TracerResolver.resolveTracer(TracerResolver.java:75) ~[opentracing-tracerresolver-0.1.4.jar:na]
	at io.opentracing.contrib.spring.web.autoconfig.TracerAutoConfiguration.getTracer(TracerAutoConfiguration.java:41) ~[opentracing-spring-web-autoconfigure-0.2.1.jar:na]
	at io.opentracing.contrib.spring.web.autoconfig.TracerAutoConfiguration$$EnhancerBySpringCGLIB$$f1d2c92.CGLIB$getTracer$0(<generated>) ~[opentracing-spring-web-autoconfigure-0.2.1.jar:na]
	at io.opentracing.contrib.spring.web.autoconfig.TracerAutoConfiguration$$EnhancerBySpringCGLIB$$f1d2c92$$FastClassBySpringCGLIB$$dbf4ecf.invoke(<generated>) ~[opentracing-spring-web-autoconfigure-0.2.1.jar:na]
	at org.springframework.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228) ~[spring-core-4.3.12.RELEASE.jar:4.3.12.RELEASE]
	at org.springframework.context.annotation.ConfigurationClassEnhancer$BeanMethodInterceptor.intercept(ConfigurationClassEnhancer.java:358) ~[spring-context-4.3.12.RELEASE.jar:4.3.12.RELEASE]
	at io.opentracing.contrib.spring.web.autoconfig.TracerAutoConfiguration$$EnhancerBySpringCGLIB$$f1d2c92.getTracer(<generated>) ~[opentracing-spring-web-autoconfigure-0.2.1.jar:na]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_172]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_172]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_172]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_172]
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:162) ~[spring-beans-4.3.12.RELEASE.jar:4.3.12.RELEASE]
	... 40 common frames omitted
Caused by: java.lang.ClassNotFoundException: org.apache.thrift.protocol.TProtocolFactory
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381) ~[na:1.8.0_172]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424) ~[na:1.8.0_172]
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349) ~[na:1.8.0_172]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[na:1.8.0_172]
	... 62 common frames omitted
```

## Short description of the changes
- The no-shadow dependency is caused by a previous fix to the test classpath. As such, we just need to add the no-shadow dependency to the test classpath.
