### PR TITLE
Fix issue where warning message is generated each time a null referen…

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
@@ -242,8 +242,11 @@ public class JaegerTracer implements Tracer, Closeable {
 
     @Override
     public JaegerTracer.SpanBuilder addReference(String referenceType, SpanContext reference) {
+      if (reference == null) {
+        return this;
+      }
       if (!(reference instanceof JaegerSpanContext)) {
-        log.warn("Expected to have a JaegerSpanContext but got " + referenceType.getClass().getName());
+        log.warn("Expected to have a JaegerSpanContext but got " + reference.getClass().getName());
         return this;
       }
 

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSpanTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSpanTest.java
@@ -31,6 +31,8 @@ import io.jaegertracing.internal.reporters.InMemoryReporter;
 import io.jaegertracing.internal.samplers.ConstSampler;
 import io.jaegertracing.spi.BaggageRestrictionManager;
 import io.opentracing.References;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
 import io.opentracing.log.Fields;
 import io.opentracing.noop.NoopSpan;
 import io.opentracing.tag.Tags;
@@ -462,6 +464,24 @@ public class JaegerSpanTest {
         .build();
     JaegerSpan jaegerSpan = tracer.buildSpan("foo")
         .asChildOf(NoopSpan.INSTANCE.context()).start();
+    jaegerSpan.finish();
+    assertTrue(jaegerSpan.getReferences().isEmpty());
+  }
+
+  @Test
+  public void testAsChildOfAcceptNull() {
+    JaegerTracer tracer = new JaegerTracer.Builder("foo")
+        .withReporter(reporter)
+        .withSampler(new ConstSampler(true))
+        .build();
+
+    JaegerSpan jaegerSpan = tracer.buildSpan("foo")
+        .asChildOf((Span) null).start();
+    jaegerSpan.finish();
+    assertTrue(jaegerSpan.getReferences().isEmpty());
+
+    jaegerSpan = tracer.buildSpan("foo")
+        .asChildOf((SpanContext) null).start();
     jaegerSpan.finish();
     assertTrue(jaegerSpan.getReferences().isEmpty());
   }

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSpanTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSpanTest.java
@@ -17,6 +17,7 @@ package io.jaegertracing.internal;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,6 +32,7 @@ import io.jaegertracing.internal.samplers.ConstSampler;
 import io.jaegertracing.spi.BaggageRestrictionManager;
 import io.opentracing.References;
 import io.opentracing.log.Fields;
+import io.opentracing.noop.NoopSpan;
 import io.opentracing.tag.Tags;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -450,5 +452,17 @@ public class JaegerSpanTest {
     foo.log(Collections.emptyMap())
         .finish();
     assertEquals(0, reporter.getSpans().size());
+  }
+
+  @Test
+  public void testAsChildOfIgnoreUnexpectedContextImpl() {
+    JaegerTracer tracer = new JaegerTracer.Builder("foo")
+        .withReporter(reporter)
+        .withSampler(new ConstSampler(true))
+        .build();
+    JaegerSpan jaegerSpan = tracer.buildSpan("foo")
+        .asChildOf(NoopSpan.INSTANCE.context()).start();
+    jaegerSpan.finish();
+    assertTrue(jaegerSpan.getReferences().isEmpty());
   }
 }

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerTracerTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerTracerTest.java
@@ -35,7 +35,6 @@ import io.jaegertracing.spi.Reporter;
 import io.jaegertracing.spi.Sampler;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
-import io.opentracing.SpanContext;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 import io.opentracing.tag.Tags;
@@ -161,22 +160,6 @@ public class JaegerTracerTest {
     tracer.close();
     verify(reporter).close();
     verify(sampler).close();
-  }
-
-  @Test
-  public void testAsChildOfAcceptNull() {
-    tracer = new JaegerTracer.Builder("foo")
-        .withReporter(new InMemoryReporter())
-        .withSampler(new ConstSampler(true))
-        .build();
-
-    JaegerSpan jaegerSpan = tracer.buildSpan("foo").asChildOf((Span) null).start();
-    jaegerSpan.finish();
-    assertTrue(jaegerSpan.getReferences().isEmpty());
-
-    jaegerSpan = tracer.buildSpan("foo").asChildOf((SpanContext) null).start();
-    jaegerSpan.finish();
-    assertTrue(jaegerSpan.getReferences().isEmpty());
   }
 
   @Test

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerTracerTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerTracerTest.java
@@ -36,8 +36,6 @@ import io.jaegertracing.spi.Sampler;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
-import io.opentracing.noop.NoopSpan;
-import io.opentracing.noop.NoopSpanContext;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 import io.opentracing.tag.Tags;
@@ -177,18 +175,6 @@ public class JaegerTracerTest {
     assertTrue(jaegerSpan.getReferences().isEmpty());
 
     jaegerSpan = tracer.buildSpan("foo").asChildOf((SpanContext) null).start();
-    jaegerSpan.finish();
-    assertTrue(jaegerSpan.getReferences().isEmpty());
-  }
-
-  @Test
-  public void testAsChildOfIgnoreUnexpectedContextImpl() {
-    tracer = new JaegerTracer.Builder("foo")
-        .withReporter(new InMemoryReporter())
-        .withSampler(new ConstSampler(true))
-        .build();
-
-    JaegerSpan jaegerSpan = tracer.buildSpan("foo").asChildOf(NoopSpan.INSTANCE.context()).start();
     jaegerSpan.finish();
     assertTrue(jaegerSpan.getReferences().isEmpty());
   }

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerTracerTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerTracerTest.java
@@ -36,6 +36,8 @@ import io.jaegertracing.spi.Sampler;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
+import io.opentracing.noop.NoopSpan;
+import io.opentracing.noop.NoopSpanContext;
 import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMap;
 import io.opentracing.tag.Tags;
@@ -175,6 +177,18 @@ public class JaegerTracerTest {
     assertTrue(jaegerSpan.getReferences().isEmpty());
 
     jaegerSpan = tracer.buildSpan("foo").asChildOf((SpanContext) null).start();
+    jaegerSpan.finish();
+    assertTrue(jaegerSpan.getReferences().isEmpty());
+  }
+
+  @Test
+  public void testAsChildOfIgnoreUnexpectedContextImpl() {
+    tracer = new JaegerTracer.Builder("foo")
+        .withReporter(new InMemoryReporter())
+        .withSampler(new ConstSampler(true))
+        .build();
+
+    JaegerSpan jaegerSpan = tracer.buildSpan("foo").asChildOf(NoopSpan.INSTANCE.context()).start();
     jaegerSpan.finish();
     assertTrue(jaegerSpan.getReferences().isEmpty());
   }


### PR DESCRIPTION
…ce is passed

Signed-off-by: Gary Brown <gary@brownuk.com>

When a null reference was being added, it was creating a warning message that was intended to detect non-JaegerSpanContext implementations. The message was also misleading as it was referring to the type of the `referenceType` (string) parameter rather than the `reference`.
