### PR TITLE
Fixes #494 - removed unwanted classes from jaeger-thrift shadowed jar

### DIFF
--- a/jaeger-crossdock/build.gradle
+++ b/jaeger-crossdock/build.gradle
@@ -13,9 +13,6 @@ compileJava {
 dependencies {
     compile project(':jaeger-client')
 
-    compile group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
-    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion
-
     compile group: 'io.opentracing.contrib', name: 'opentracing-jaxrs2', version: '0.1.4'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
     compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: jerseyVersion

--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -6,7 +6,7 @@ description = 'Library to send data to Jaeger backend components via Thrift'
 dependencies {
     compile project(':jaeger-core')
 
-    compile group: 'org.slf4j', name: 'slf4j-api'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
 
     compileOnly group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
     compileOnly group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion

--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -6,6 +6,8 @@ description = 'Library to send data to Jaeger backend components via Thrift'
 dependencies {
     compile project(':jaeger-core')
 
+    compile group: 'org.slf4j', name: 'slf4j-api'
+
     compileOnly group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
     compileOnly group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion
 
@@ -51,13 +53,18 @@ jar {
 
 shadowJar {
     baseName = 'jaeger-thrift'
-    relocate 'com.google.gson'  , 'jaeger.com.google.gson'
-    relocate 'com.twitter'      , 'jaeger.com.twitter'
-    relocate 'okhttp'           , 'jaeger.okhttp'
-    relocate 'okio'             , 'jaeger.okio'
-    relocate 'org.apache'       , 'jaeger.org.apache'
+    relocate 'com.google.gson'  , 'io.jaegertracing.vendor.com.google.gson'
+    relocate 'com.twitter'      , 'io.jaegertracing.vendor.com.twitter'
+    relocate 'okhttp'           , 'io.jaegertracing.vendor.okhttp'
+    relocate 'okio'             , 'io.jaegertracing.vendor.okio'
+    relocate 'org.apache'       , 'io.jaegertracing.vendor.org.apache'
     classifier null
     configurations = [project.configurations.compileOnly]
+    dependencies {
+        exclude(dependency('org.slf4j:slf4j-api'))
+        exclude(dependency('org.projectlombok:lombok'))
+        exclude(dependency('org.codehaus.mojo:animal-sniffer-annotations'))
+    }
 }
 
 task testJar(type: Jar, dependsOn: testClasses) {


### PR DESCRIPTION
Moved relocated packages to `io.jaegertracing.vendor`
Excluded lombok and animal-sniffer from shadow plugin in `jaeger-thrift`
Added slf4j as runtime non-relocated dependency
Removed unused dependencies from `jaeger-crossdock`

I really believe `slf4j-api` should be normal runtime dependency, having it shadowed is not a good idea - it depends on external loggers to work. Relocating slf4j-api breaks that at best, crashes at worst.
(note: `slf4j-api` is transitive dependency of `libthrift`)