### PR TITLE
Support for 128 bits trace ids

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
@@ -148,6 +148,11 @@ public class Configuration {
   public static final String JAEGER_SENDER_FACTORY = JAEGER_PREFIX + "SENDER_FACTORY";
 
   /**
+   *  Opt-in to use 128 bit traceIds. By default, uses 64 bits.
+   */
+  public static final String JAEGER_TRACEID_128BIT = JAEGER_PREFIX + "TRACEID_128BIT";
+
+  /**
    * The supported trace context propagation formats.
    */
   public enum Propagation {
@@ -172,6 +177,7 @@ public class Configuration {
   private CodecConfiguration codecConfig;
   private MetricsFactory metricsFactory;
   private Map<String, String> tracerTags;
+  private boolean useTraceId128Bit;
 
   /**
    * lazy singleton JaegerTracer initialized in getTracer() method.
@@ -193,6 +199,7 @@ public class Configuration {
   public static Configuration fromEnv(String serviceName) {
     return new Configuration(serviceName)
             .withTracerTags(tracerTagsFromEnv())
+            .withTraceId128Bit(getPropertyAsBool(JAEGER_TRACEID_128BIT))
             .withReporter(ReporterConfiguration.fromEnv())
             .withSampler(SamplerConfiguration.fromEnv())
             .withCodec(CodecConfiguration.fromEnv());
@@ -219,6 +226,9 @@ public class Configuration {
         .withReporter(reporter)
         .withMetrics(metrics)
         .withTags(tracerTags);
+    if (useTraceId128Bit) {
+      builder = builder.withTraceId128Bit();
+    }
     codecConfig.apply(builder);
     return builder;
   }
@@ -282,6 +292,11 @@ public class Configuration {
 
   public Configuration withCodec(CodecConfiguration codecConfig) {
     this.codecConfig = codecConfig;
+    return this;
+  }
+
+  public Configuration withTraceId128Bit(boolean useTraceId128Bit) {
+    this.useTraceId128Bit = useTraceId128Bit;
     return this;
   }
 

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerObjectFactory.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerObjectFactory.java
@@ -57,13 +57,14 @@ public class JaegerObjectFactory {
   }
 
   public JaegerSpanContext createSpanContext(
-      long traceId,
+      long traceIdHigh,
+      long traceIdLow,
       long spanId,
       long parentId,
       byte flags,
       Map<String, String> baggage,
       String debugId) {
-    return new JaegerSpanContext(traceId, spanId, parentId, flags, baggage, debugId, this);
+    return new JaegerSpanContext(traceIdHigh, traceIdLow, spanId, parentId, flags, baggage, debugId, this);
   }
 
   public JaegerTracer.SpanBuilder createSpanBuilder(JaegerTracer tracer, String operationName) {

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/exceptions/TraceIdOutOfBoundException.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/exceptions/TraceIdOutOfBoundException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018, The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.jaegertracing.internal.exceptions;
+
+public class TraceIdOutOfBoundException extends RuntimeException {
+
+  private static final long serialVersionUID = 2332452744805504972L;
+
+  public TraceIdOutOfBoundException(String message) {
+    super(message);
+  }
+}

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSubclassTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSubclassTest.java
@@ -107,14 +107,15 @@ public class JaegerSubclassTest {
 
   private static class CustomSpanContext extends JaegerSpanContext {
     private CustomSpanContext(
-        long traceId,
+        long traceIdHigh,
+        long traceIdLow,
         long spanId,
         long parentId,
         byte flags,
         Map<String, String> baggage,
         String debugId,
         CustomObjectFactory objectFactory) {
-      super(traceId, spanId, parentId, flags, baggage, debugId, objectFactory);
+      super(traceIdHigh, traceIdLow, spanId, parentId, flags, baggage, debugId, objectFactory);
     }
   }
 
@@ -142,13 +143,14 @@ public class JaegerSubclassTest {
 
     @Override
     public CustomSpanContext createSpanContext(
-        long traceId,
+        long traceIdHigh,
+        long traceIdLow,
         long spanId,
         long parentId,
         byte flags,
         Map<String, String> baggage,
         String debugId) {
-      return new CustomSpanContext(traceId, spanId, parentId, flags, baggage, debugId, this);
+      return new CustomSpanContext(traceIdHigh, traceIdLow, spanId, parentId, flags, baggage, debugId, this);
     }
 
     @Override

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerTracerTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerTracerTest.java
@@ -67,6 +67,18 @@ public class JaegerTracerTest {
   }
 
   @Test
+  public void testTraceId64Bit() {
+    JaegerTracer tracer = new Builder("name").build();
+    assertFalse(tracer.isUseTraceId128Bit());
+  }
+
+  @Test
+  public void testTraceId128Bit() {
+    JaegerTracer tracer = new Builder("name").withTraceId128Bit().build();
+    assertTrue(tracer.isUseTraceId128Bit());
+  }
+
+  @Test
   public void testBuildSpan() {
     String expectedOperation = "fry";
     JaegerSpan jaegerSpan = tracer.buildSpan(expectedOperation).start();

--- a/jaeger-crossdock/src/main/java/io/jaegertracing/crossdock/resources/behavior/TraceBehavior.java
+++ b/jaeger-crossdock/src/main/java/io/jaegertracing/crossdock/resources/behavior/TraceBehavior.java
@@ -94,7 +94,7 @@ public class TraceBehavior {
     }
 
     JaegerSpanContext context = span.context();
-    String traceId = String.format("%x", context.getTraceId());
+    String traceId = context.getTraceId();
     boolean sampled = context.isSampled();
     String baggage = span.getBaggageItem(Constants.BAGGAGE_KEY);
     return new ObservedSpan(traceId, sampled, baggage);

--- a/jaeger-crossdock/src/test/java/io/jaegertracing/crossdock/resources/behavior/http/TraceBehaviorResourceTest.java
+++ b/jaeger-crossdock/src/test/java/io/jaegertracing/crossdock/resources/behavior/http/TraceBehaviorResourceTest.java
@@ -104,7 +104,7 @@ public class TraceBehaviorResourceTest {
   @Test
   public void testStartTraceHttp() throws Exception {
     Scope scope = server.getTracer().buildSpan("root").startActive(true);
-    String expectedTraceId = String.format("%x", ((JaegerSpanContext)scope.span().context()).getTraceId());
+    String expectedTraceId = ((JaegerSpanContext)scope.span().context()).getTraceId();
     String expectedBaggage = "baggage-example";
 
     Downstream downstream =
@@ -152,8 +152,8 @@ public class TraceBehaviorResourceTest {
     TraceResponse traceResponse = resp.readEntity(TraceResponse.class);
 
     assertNotNull(traceResponse.getDownstream());
-    validateTraceResponse(traceResponse, String.format("%x",
-        ((JaegerSpanContext)scope.span().context()).getTraceId()), expectedBaggage, 2);
+    validateTraceResponse(traceResponse,
+            ((JaegerSpanContext)scope.span().context()).getTraceId(), expectedBaggage, 2);
     scope.close();
   }
 

--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/reporters/protocols/JaegerThriftSpanConverter.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/reporters/protocols/JaegerThriftSpanConverter.java
@@ -44,8 +44,8 @@ public class JaegerThriftSpanConverter {
         : buildReferences(jaegerSpan.getReferences());
 
     return new io.jaegertracing.thriftjava.Span(
-        context.getTraceId(),
-        0, // TraceIdHigh is currently not supported
+        context.getTraceIdLow(),
+        context.getTraceIdHigh(),
         context.getSpanId(),
         oneChildOfParent ? context.getParentId() : 0,
         jaegerSpan.getOperationName(),
@@ -63,8 +63,8 @@ public class JaegerThriftSpanConverter {
     for (Reference reference: references) {
       SpanRefType thriftRefType = References.CHILD_OF.equals(reference.getType()) ? SpanRefType.CHILD_OF :
               SpanRefType.FOLLOWS_FROM;
-      thriftReferences.add(new SpanRef(thriftRefType, reference.getSpanContext().getTraceId(),
-              0, reference.getSpanContext().getSpanId()));
+      thriftReferences.add(new SpanRef(thriftRefType, reference.getSpanContext().getTraceIdLow(),
+              reference.getSpanContext().getTraceIdHigh(), reference.getSpanContext().getSpanId()));
     }
 
     return thriftReferences;

--- a/jaeger-zipkin/src/main/java/io/jaegertracing/zipkin/internal/ThriftSpanConverter.java
+++ b/jaeger-zipkin/src/main/java/io/jaegertracing/zipkin/internal/ThriftSpanConverter.java
@@ -42,12 +42,13 @@ public class ThriftSpanConverter {
 
     JaegerSpanContext context = jaegerSpan.context();
     return new com.twitter.zipkin.thriftjava.Span(
-            context.getTraceId(),
+            context.getTraceIdLow(),
             jaegerSpan.getOperationName(),
             context.getSpanId(),
             buildAnnotations(jaegerSpan, host),
             buildBinaryAnnotations(jaegerSpan, host))
         .setParent_id(context.getParentId())
+        .setTrace_id_high(context.getTraceIdHigh())
         .setDebug(context.isDebug())
         .setTimestamp(jaegerSpan.getStart())
         .setDuration(jaegerSpan.getDuration());

--- a/jaeger-zipkin/src/main/java/io/jaegertracing/zipkin/internal/V2SpanConverter.java
+++ b/jaeger-zipkin/src/main/java/io/jaegertracing/zipkin/internal/V2SpanConverter.java
@@ -45,7 +45,7 @@ public class V2SpanConverter {
     JaegerSpanContext context = span.context();
     zipkin2.Span.Builder builder = zipkin2.Span.newBuilder()
             .id(Long.toHexString(context.getSpanId()))
-            .traceId(Long.toHexString(context.getTraceId()))
+            .traceId(context.getTraceIdHigh(), context.getTraceIdLow())
             .name(span.getOperationName())
             .parentId(Long.toHexString(context.getParentId()))
             .debug(context.isDebug())

--- a/jaeger-zipkin/src/test/java/io/jaegertracing/zipkin/internal/ThriftSpanConverterTest.java
+++ b/jaeger-zipkin/src/test/java/io/jaegertracing/zipkin/internal/ThriftSpanConverterTest.java
@@ -14,10 +14,11 @@
 
 package io.jaegertracing.zipkin.internal;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
@@ -50,14 +51,16 @@ import org.junit.runner.RunWith;
 @RunWith(DataProviderRunner.class)
 public class ThriftSpanConverterTest {
   JaegerTracer tracer;
+  JaegerTracer tracer128;
 
   @Before
   public void setUp() {
-    tracer = new JaegerTracer.Builder("test-service-name")
+    final JaegerTracer.Builder tracerBuilder = new JaegerTracer.Builder("test-service-name")
             .withReporter(new InMemoryReporter())
             .withSampler(new ConstSampler(true))
-            .withZipkinSharedRpcSpan()
-            .build();
+            .withZipkinSharedRpcSpan();
+    tracer = tracerBuilder.build();
+    tracer128 = tracerBuilder.withTraceId128Bit().build();
   }
 
   // undef value is used to mark tags that should *not* be present
@@ -304,5 +307,15 @@ public class ThriftSpanConverterTest {
     expectedValues.add("{\"boolean\":true,\"event\":\"structured data\",\"number\":42,\"string\":\"something\"}");
 
     assertEquals("zipkin span should contain matching annotations for span logs", expectedValues, annotationValues);
+  }
+
+  @Test
+  public void testConvertSpanWith128BitTraceId() {
+    JaegerSpan span = tracer128.buildSpan("operation-name").start();
+
+    com.twitter.zipkin.thriftjava.Span zipkinSpan = ThriftSpanConverter.convertSpan(span);
+    assertNotEquals(0, span.context().getTraceIdHigh());
+    assertEquals(span.context().getTraceIdLow(), zipkinSpan.getTrace_id());
+    assertEquals(span.context().getTraceIdHigh(), zipkinSpan.getTrace_id_high());
   }
 }


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes #495 : support for 128 bits trace ids.

## Short description of the changes
Added environment variable JAEGER_TRACEID_128BIT
Added TraceId and SpanId classes
Added withTraceId128Bit method to Configuration
Added withTraceId128Bit method to Tracer.Builder
Added useTraceId128Bit property to Tracer

Inspired from https://github.com/jaegertracing/jaeger-client-csharp/pull/94