### PR TITLE
Allow subclassing of common classes

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018, The Jaeger Authors
  * Copyright (c) 2016, Uber Technologies, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -213,13 +214,17 @@ public class Configuration {
     Metrics metrics = new Metrics(metricsFactory);
     Reporter reporter = reporterConfig.getReporter(metrics);
     Sampler sampler = samplerConfig.createSampler(serviceName, metrics);
-    JaegerTracer.Builder builder = new JaegerTracer.Builder(serviceName)
+    JaegerTracer.Builder builder = createTracerBuilder(serviceName)
         .withSampler(sampler)
         .withReporter(reporter)
         .withMetrics(metrics)
         .withTags(tracerTags);
     codecConfig.apply(builder);
     return builder;
+  }
+
+  protected JaegerTracer.Builder createTracerBuilder(String serviceName) {
+    return new JaegerTracer.Builder(serviceName);
   }
 
   public synchronized JaegerTracer getTracer() {

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerObjectFactory.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerObjectFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2018, The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.jaegertracing.internal;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Implements abstract factory pattern for creating spans, span contexts, and span builders. This
+ * pattern allows subclasses of JaegerSpan, JaegerSpanContext, and JaegerTracer.SpanBuilder to be
+ * used consistently in the trace instead of the base class.
+ *
+ * <p>Example usage:</p>
+ *
+ * <pre>{@code
+ *     public class CustomObjectFactory extends JaegerObjectFactory {
+ *         \@Override
+ *         public JaegerSpan createSpan(...) {
+ *           return new CustomSpan(...);
+ *         }
+ *
+ *         // Override other methods...
+ *     }
+ * }</pre>
+ */
+public class JaegerObjectFactory {
+  public JaegerSpan createSpan(
+      JaegerTracer tracer,
+      String operationName,
+      JaegerSpanContext context,
+      long startTimeMicroseconds,
+      long startTimeNanoTicks,
+      boolean computeDurationViaNanoTicks,
+      Map<String, Object> tags,
+      List<Reference> references) {
+    return new JaegerSpan(
+        tracer,
+        operationName,
+        context,
+        startTimeMicroseconds,
+        startTimeNanoTicks,
+        computeDurationViaNanoTicks,
+        tags,
+        references);
+  }
+
+  public JaegerSpanContext createSpanContext(
+      long traceId,
+      long spanId,
+      long parentId,
+      byte flags,
+      Map<String, String> baggage,
+      String debugId) {
+    return new JaegerSpanContext(traceId, spanId, parentId, flags, baggage, debugId, this);
+  }
+
+  public JaegerTracer.SpanBuilder createSpanBuilder(JaegerTracer tracer, String operationName) {
+    return tracer.new SpanBuilder(operationName);
+  }
+}

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018, The Jaeger Authors
  * Copyright (c) 2016, Uber Technologies, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -46,7 +47,7 @@ public class JaegerSpan implements Span {
   private List<LogData> logs;
   private boolean finished = false; // to prevent the same span from getting reported multiple times
 
-  JaegerSpan(
+  protected JaegerSpan(
       JaegerTracer tracer,
       String operationName,
       JaegerSpanContext context,

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSpanTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSpanTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018, The Jaeger Authors
  * Copyright (c) 2016, Uber Technologies, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -214,7 +215,7 @@ public class JaegerSpanTest {
         tracer,
         operation,
         new JaegerSpanContext(
-            1, 2, 3, (byte) 4, Collections.emptyMap(), null /* debugId */),
+            1, 2, 3, (byte) 4, Collections.emptyMap(), null /* debugId */, new JaegerObjectFactory()),
         0,
         0,
         false,

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSubclassTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSubclassTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2018, The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.jaegertracing.internal;
+
+import io.jaegertracing.Configuration;
+import io.opentracing.Scope;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JaegerSubclassTest {
+  private static class CustomConfiguration extends Configuration {
+    private CustomConfiguration(String serviceName) {
+      super(serviceName);
+    }
+
+    @Override
+    public CustomTracer.CustomBuilder getTracerBuilder() {
+      return (CustomTracer.CustomBuilder) super.getTracerBuilder();
+    }
+
+    @Override
+    public synchronized CustomTracer getTracer() {
+      return (CustomTracer) super.getTracer();
+    }
+
+    @Override
+    protected CustomTracer.CustomBuilder createTracerBuilder(String serviceName) {
+      return new CustomTracer.CustomBuilder(serviceName);
+    }
+  }
+
+  private static class CustomTracer extends JaegerTracer {
+    public static class CustomBuilder extends JaegerTracer.Builder {
+      private CustomBuilder(String serviceName) {
+        super(serviceName, new CustomObjectFactory());
+      }
+
+      @Override
+      public CustomTracer build() {
+        return (CustomTracer) super.build();
+      }
+
+      @Override
+      protected JaegerTracer createTracer() {
+        return new CustomTracer(this);
+      }
+    }
+
+    public class CustomSpanBuilder extends JaegerTracer.SpanBuilder {
+      protected CustomSpanBuilder(String operationName) {
+        super(operationName);
+      }
+
+      @Override
+      public CustomSpan start() {
+        return (CustomSpan) super.start();
+      }
+    }
+
+    private CustomTracer(CustomBuilder builder) {
+      super(builder);
+    }
+  }
+
+  private static class CustomSpan extends JaegerSpan {
+    private CustomSpan(
+        CustomTracer tracer,
+        String operationName,
+        CustomSpanContext context,
+        long startTimeMicroseconds,
+        long startTimeNanoTicks,
+        boolean computeDurationViaNanoTicks,
+        Map<String, Object> tags,
+        List<Reference> references) {
+      super(
+          tracer,
+          operationName,
+          context,
+          startTimeMicroseconds,
+          startTimeNanoTicks,
+          computeDurationViaNanoTicks,
+          tags,
+          references);
+    }
+
+    @Override
+    public CustomSpanContext context() {
+      return (CustomSpanContext) super.context();
+    }
+  }
+
+  private static class CustomSpanContext extends JaegerSpanContext {
+    private CustomSpanContext(
+        long traceId,
+        long spanId,
+        long parentId,
+        byte flags,
+        Map<String, String> baggage,
+        String debugId,
+        CustomObjectFactory objectFactory) {
+      super(traceId, spanId, parentId, flags, baggage, debugId, objectFactory);
+    }
+  }
+
+  private static class CustomObjectFactory extends JaegerObjectFactory {
+    @Override
+    public CustomSpan createSpan(
+        JaegerTracer tracer,
+        String operationName,
+        JaegerSpanContext context,
+        long startTimeMicroseconds,
+        long startTimeNanoTicks,
+        boolean computeDurationViaNanoTicks,
+        Map<String, Object> tags,
+        List<Reference> references) {
+      return new CustomSpan(
+          (CustomTracer) tracer,
+          operationName,
+          (CustomSpanContext) context,
+          startTimeMicroseconds,
+          startTimeNanoTicks,
+          computeDurationViaNanoTicks,
+          tags,
+          references);
+    }
+
+    @Override
+    public CustomSpanContext createSpanContext(
+        long traceId,
+        long spanId,
+        long parentId,
+        byte flags,
+        Map<String, String> baggage,
+        String debugId) {
+      return new CustomSpanContext(traceId, spanId, parentId, flags, baggage, debugId, this);
+    }
+
+    @Override
+    public CustomTracer.CustomSpanBuilder createSpanBuilder(
+        JaegerTracer tracer, String operationName) {
+      return ((CustomTracer) tracer).new CustomSpanBuilder(operationName);
+    }
+  }
+
+  @Test
+  public void testTracer() {
+    final CustomConfiguration config = new CustomConfiguration("test-service");
+    final CustomTracer.CustomBuilder builder = config.getTracerBuilder();
+    final CustomTracer tracer = builder.build();
+    final Scope scope = tracer.buildSpan("test-operation").startActive(true);
+    Assert.assertNotNull(tracer.scopeManager().active());
+    Assert.assertTrue(tracer.scopeManager().active().span() instanceof CustomSpan);
+    Assert.assertTrue(tracer.scopeManager().active().span().context() instanceof CustomSpanContext);
+    scope.close();
+    config.closeTracer();
+  }
+}


### PR DESCRIPTION
Give protected access to core Jaeger classes so that users may extend them. The main motive here is to create a bridge between the legacy `com.uber.jaeger` classes to the `io.jaegertracing` classes (equivalent to a `typedef` in C/C++). **Note, in general it would not be wise to implement a subclass of these classes because they are internal and may change without notice!**

Additionally, implement abstract factory pattern to create instances of spans, span contexts, and span builders. This allows the caller to provide subclasses of the aforementioned classes. For example, when the tracer needs to create a `JaegerSpanBuilder` object, it invokes `createSpanBuilder` instead. `createSpanBuilder` acts as a hook to instantiate a subclass instead of the `JaegerSpanBuilder` base class.