### PR TITLE
Add possibility to specify serviceName with 'fromEnv'

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
@@ -186,11 +186,15 @@ public class Configuration {
    * @return Configuration object from environmental variables
    */
   public static Configuration fromEnv() {
-    return new Configuration(getProperty(JAEGER_SERVICE_NAME))
-        .withTracerTags(tracerTagsFromEnv())
-        .withReporter(ReporterConfiguration.fromEnv())
-        .withSampler(SamplerConfiguration.fromEnv())
-        .withCodec(CodecConfiguration.fromEnv());
+    return Configuration.fromEnv(getProperty(JAEGER_SERVICE_NAME));
+  }
+
+  public static Configuration fromEnv(String serviceName) {
+    return new Configuration(serviceName)
+            .withTracerTags(tracerTagsFromEnv())
+            .withReporter(ReporterConfiguration.fromEnv())
+            .withSampler(SamplerConfiguration.fromEnv())
+            .withCodec(CodecConfiguration.fromEnv());
   }
 
   public JaegerTracer.Builder getTracerBuilder() {


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- It's currently not possible to easily explicitly set the service name *and* have all the other values coming from env vars. Either the consuming application needs to set a system property and possibly clear it afterwards, or needs to call all other relevant `with` methods (`withTracerTags` being the most problematic one, IMO). 

Setting/clearing a system property might be trivial for single tenant JVM instances, but it's a problem when the JVM has multiple tenants, which is usually the case for application servers like WildFly.

## Short description of the changes
- Added a `Configuration.fromEnv(String)` method based on the existing `Configuration.fromEnv()` one
- Changed `Configuration.fromEnv()` to use the new method, passing `JAEGER_SERVICE_NAME` as the `serviceName`.