### PR TITLE
Move jaeger-thrift shadow jar to its own classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ This will bring a concrete sender, such as `jaeger-thrift`, as well as the `jaeg
 
 ### Thrift version conflicts
 The Jaeger Java Client uses `org.apache.thrift:libthrift:0.11.0`. By default, declaring a dependency on the
-`jaeger-thrift` module will bring a shaded version of Thrift (and others), making it safe to use your own versions of
-such dependencies. A non-shaded version of the dependency is available with the classifier `no-shadow`, but the
-transitive dependencies (Thrift included) will have to be added manually to your project.
+`jaeger-thrift` module will bring a non-shaded version of Thrift (and others). A shaded version of the dependency is
+available with the classifier `shadow`.
 
 ## Instantiating the Tracer
 

--- a/jaeger-client/build.gradle
+++ b/jaeger-client/build.gradle
@@ -1,8 +1,7 @@
 description = 'Convenience module to be used by instrumented applications'
 
 dependencies {
-    // for the other projects, we can add the dependency on the projects themselves
-    compile project(path: ':jaeger-thrift', configuration: "shadow")
+    compile project(':jaeger-thrift')
     compile project(':jaeger-core')
     compile project(':jaeger-tracerresolver')
 

--- a/jaeger-crossdock/build.gradle
+++ b/jaeger-crossdock/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.github.johnrengelman.shadow'
 
-
 description = 'A jaeger instrumented java server meant for testing interoperability with different Jaeger clients through the use of crossdock (https://github.com/crossdock/crossdock)'
 ext.jacksonVersion = '2.8.10'
 shadowJar.archiveName = 'jaeger-crossdock.jar'
@@ -13,15 +12,15 @@ compileJava {
 dependencies {
     compile project(':jaeger-client')
 
-    compile group: 'io.opentracing.contrib', name: 'opentracing-jaxrs2', version: '0.1.4'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
+    compile group: 'io.opentracing.contrib', name: 'opentracing-jaxrs2', version: '0.1.4'
+    compile group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.0'
+    compile group: 'javax.servlet', name: 'servlet-api', version: '2.5'
+    compile group: 'org.glassfish.grizzly', name: 'grizzly-http-servlet', version: '2.3.23'
     compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-http', version: jerseyVersion
     compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-servlet', version: jerseyVersion
-    compile group: 'org.glassfish.grizzly', name: 'grizzly-http-servlet', version: '2.3.23'
-    compile group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.0'
     compile group: 'org.glassfish.jersey.core', name: 'jersey-client', version: jerseyVersion
     compile group: 'org.glassfish.jersey.media', name: 'jersey-media-json-jackson', version: jerseyVersion
-    compile group: 'javax.servlet', name: 'servlet-api', version: '2.5'
     compile group: 'org.slf4j', name: 'slf4j-log4j12', version: slf4jVersion
 
     // Testing Frameworks

--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -7,18 +7,13 @@ dependencies {
     compile project(':jaeger-core')
 
     compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
-
-    compileOnly group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
-    compileOnly group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion
+    compile group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
+    compile group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion
 
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'com.tngtech.java', name: 'junit-dataprovider', version: junitDataProviderVersion
     testCompile group: 'org.awaitility', name: 'awaitility', version: awaitilityVersion
     testCompile group: 'org.glassfish.jersey.test-framework.providers', name: 'jersey-test-framework-provider-grizzly2', version: jerseyVersion
-
-    // compileOnly dependencies aren't visible to tests
-    testCompile group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion
-    testCompile group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
 
     signature 'org.codehaus.mojo.signature:java16:1.1@signature'
 }
@@ -47,19 +42,13 @@ licenseMain.enabled = false
 checkstyleMain.enabled = false
 checkstyleTest.enabled = false
 
-jar {
-    classifier 'no-shadow'
-}
-
 shadowJar {
-    baseName = 'jaeger-thrift'
     relocate 'com.google.gson'  , 'io.jaegertracing.vendor.com.google.gson'
     relocate 'com.twitter'      , 'io.jaegertracing.vendor.com.twitter'
     relocate 'okhttp'           , 'io.jaegertracing.vendor.okhttp'
     relocate 'okio'             , 'io.jaegertracing.vendor.okio'
     relocate 'org.apache'       , 'io.jaegertracing.vendor.org.apache'
-    classifier null
-    configurations = [project.configurations.compileOnly]
+    classifier 'shadow'
     dependencies {
         exclude(dependency('org.slf4j:slf4j-api'))
         exclude(dependency('org.projectlombok:lombok'))

--- a/jaeger-zipkin/build.gradle
+++ b/jaeger-zipkin/build.gradle
@@ -3,9 +3,6 @@ description = 'Integration library for Zipkin'
 dependencies {
     compile project(':jaeger-client')
 
-    // For some reason, we need to use the default configuration here to get access to the Thrift-generated classes
-    compile project(path: ':jaeger-thrift', configuration: "default")
-
     compile group: 'io.zipkin.reporter2', name: 'zipkin-sender-urlconnection', version: '2.7.6'
     compile group: 'org.apache.thrift', name: 'libthrift', version: apacheThriftVersion
 


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- By default, libraries usually provide non-shadow JARs, unless explicitly specified via, for instance, Maven classifiers. We thought that providing a shadowed version by default would help most users, but this is getting more complicated that it deserves. 
- Having the shadow by default makes it harder for our users to assess what's running and at which version.

## Short description of the changes
- Revert the relevant parts of #461

Also related: #486, #494 / #498

cc @mdvorak
