### PR TITLE
Mark gson field in HttpSamplingManager as ignored for toString

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/HttpSamplingManager.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/HttpSamplingManager.java
@@ -26,7 +26,7 @@ import java.net.URLEncoder;
 import lombok.ToString;
 
 
-@ToString
+@ToString(exclude = "gson")
 public class HttpSamplingManager implements SamplingManager {
   public static final String DEFAULT_HOST_PORT = "localhost:5778";
   private final Gson gson = new Gson();


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
Before:

> 2018-08-22 10:29:09 INFO  Configuration:231 - Initialized tracer=JaegerTracer(version=Java-0.30.4, serviceName=vertx-create-span, reporter=RemoteReporter(queueProcessor=RemoteReporter.QueueProcessor(open=true), sender=UdpSender(udpTransport=ThriftUdpTransport(socket=java.net.DatagramSocket@b9387eb, receiveBuf=null, receiveOffSet=-1, receiveLength=0)), closeEnqueueTimeout=1000), sampler=RemoteControlledSampler(maxOperations=2000, serviceName=vertx-create-span, manager=HttpSamplingManager(gson={serializeNulls:false,factories:[Factory[typeHierarchy=com.google.gson.JsonElement,adapter=com.google.gson.internal.bind.TypeAdapters$29@579d530e], com.google.gson.internal.bind.ObjectTypeAdapter$1@2dc6b149, com.google.gson.internal.Excluder@403cd3a7, Factory[type=java.lang.String,adapter=com.google.gson.internal.bind.TypeAdapters$16@5ee2dbb7], Factory[type=java.lang.Integer+int,adapter=com.google.gson.internal.bind.TypeAdapters$7@635ae646], Factory[type=java.lang.Boolean+boolean,adapter=com.google.gson.internal.bind.TypeAdapters$3@7b0e5f9d], Factory[type=java.lang.Byte+byte,adapter=com.google.gson.internal.bind.TypeAdapters$5@5d091ab0], Factory[type=java.lang.Short+short,adapter=com.google.gson.internal.bind.TypeAdapters$6@15fe5dc5], Factory[type=java.lang.Long+long,adapter=com.google.gson.internal.bind.TypeAdapters$11@2122e1ea], Factory[type=java.lang.Double+double,adapter=com.google.gson.Gson$1@28d9b0e4], Factory[type=java.lang.Float+float,adapter=com.google.gson.Gson$2@3d90e3d5], Factory[type=java.lang.Number,adapter=com.google.gson.internal.bind.TypeAdapters$14@5a6781d7], Factory[type=java.util.concurrent.atomic.AtomicInteger,adapter=com.google.gson.TypeAdapter$1@6cfc06c0], Factory[type=java.util.concurrent.atomic.AtomicBoolean,adapter=com.google.gson.TypeAdapter$1@9c7c52b], Factory[type=java.util.concurrent.atomic.AtomicLong,adapter=com.google.gson.TypeAdapter$1@33f3018d], Factory[type=java.util.concurrent.atomic.AtomicLongArray,adapter=com.google.gson.TypeAdapter$1@557c471d], Factory[type=java.util.concurrent.atomic.AtomicIntegerArray,adapter=com.google.gson.TypeAdapter$1@593a8174], Factory[type=java.lang.Character+char,adapter=com.google.gson.internal.bind.TypeAdapters$15@6ee3e9e5], Factory[type=java.lang.StringBuilder,adapter=com.google.gson.internal.bind.TypeAdapters$19@453762dd], Factory[type=java.lang.StringBuffer,adapter=com.google.gson.internal.bind.TypeAdapters$20@72c491c9], Factory[type=java.math.BigDecimal,adapter=com.google.gson.internal.bind.TypeAdapters$17@7ff88fc4], Factory[type=java.math.BigInteger,adapter=com.google.gson.internal.bind.TypeAdapters$18@ea5ed1f], Factory[type=java.net.URL,adapter=com.google.gson.internal.bind.TypeAdapters$21@70fa579c], Factory[type=java.net.URI,adapter=com.google.gson.internal.bind.TypeAdapters$22@26e6da93], Factory[type=java.util.UUID,adapter=com.google.gson.internal.bind.TypeAdapters$24@1ddbe724], Factory[type=java.util.Currency,adapter=com.google.gson.TypeAdapter$1@3cb73c95], Factory[type=java.util.Locale,adapter=com.google.gson.internal.bind.TypeAdapters$28@1ed3da28], Factory[typeHierarchy=java.net.InetAddress,adapter=com.google.gson.internal.bind.TypeAdapters$23@e71b923], Factory[type=java.util.BitSet,adapter=com.google.gson.TypeAdapter$1@4c519d0e], com.google.gson.internal.bind.DateTypeAdapter$1@49074385, Factory[type=java.util.Calendar+java.util.GregorianCalendar,adapter=com.google.gson.internal.bind.TypeAdapters$27@4905c217], com.google.gson.internal.bind.TimeTypeAdapter$1@4a3ec2b5, com.google.gson.internal.bind.SqlDateTypeAdapter$1@ac79f11, com.google.gson.internal.bind.TypeAdapters$26@792feea7, com.google.gson.internal.bind.ArrayTypeAdapter$1@1edd9eef, Factory[type=java.lang.Class,adapter=com.google.gson.TypeAdapter$1@224adceb], com.google.gson.internal.bind.CollectionTypeAdapterFactory@1443e0a4, com.google.gson.internal.bind.MapTypeAdapterFactory@129f7e5d, com.google.gson.internal.bind.JsonAdapterAnnotationTypeAdapterFactory@6047b007, com.google.gson.internal.bind.TypeAdapters$30@141e8560, com.google.gson.internal.bind.ReflectiveTypeAdapterFactory@1fd30187],instanceCreators:{}}, hostPort=localhost:5778), metrics=io.jaegertracing.internal.metrics.Metrics@7657e9b6, sampler=ProbabilisticSampler(positiveSamplingBoundary=9223372036854776, negativeSamplingBoundary=-9223372036854776, samplingRate=0.001, tags={sampler.type=probabilistic, sampler.param=0.001})), ipv4=-1062731769, tags={hostname=caju.kroehling.de, jaeger.version=Java-0.30.4, ip=192.168.0.7}, zipkinSharedRpcSpan=false, baggageSetter=io.jaegertracing.internal.baggage.BaggageSetter@2b4da8f3, expandExceptionLogs=false)

## Short description of the changes
After

> 2018-08-22 10:33:50 INFO  Configuration:231 - Initialized tracer=JaegerTracer(version=Java-0.30.5-SNAPSHOT, serviceName=vertx-create-span, reporter=RemoteReporter(queueProcessor=RemoteReporter.QueueProcessor(open=true), sender=UdpSender(udpTransport=ThriftUdpTransport(socket=java.net.DatagramSocket@44f18aee, receiveBuf=null, receiveOffSet=-1, receiveLength=0)), closeEnqueueTimeout=1000), sampler=RemoteControlledSampler(maxOperations=2000, serviceName=vertx-create-span, manager=HttpSamplingManager(hostPort=localhost:5778), metrics=io.jaegertracing.internal.metrics.Metrics@5b6394c, sampler=ProbabilisticSampler(positiveSamplingBoundary=9223372036854776, negativeSamplingBoundary=-9223372036854776, samplingRate=0.001, tags={sampler.type=probabilistic, sampler.param=0.001})), ipv4=-1062731769, tags={hostname=caju.kroehling.de, jaeger.version=Java-0.30.5-SNAPSHOT, ip=192.168.0.7}, zipkinSharedRpcSpan=false, baggageSetter=io.jaegertracing.internal.baggage.BaggageSetter@5aa9aa1, expandExceptionLogs=false)