### PR TITLE
Fine-tune bootstrap logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,8 +140,8 @@ subprojects {
     }
 
     dependencies {
-        annotationProcessor 'org.projectlombok:lombok:1.16.18'
-        compileOnly 'org.projectlombok:lombok:1.16.18'
+        annotationProcessor 'org.projectlombok:lombok:1.18.2'
+        compileOnly 'org.projectlombok:lombok:1.18.2'
         compileOnly 'org.codehaus.mojo:animal-sniffer-annotations:1.16'
     }
 

--- a/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
@@ -250,7 +250,7 @@ public class Configuration {
     Iterator<MetricsFactory> iterator = loader.iterator();
     if (iterator.hasNext()) {
       MetricsFactory metricsFactory = iterator.next();
-      log.info("Found a Metrics Factory service: {}", metricsFactory.getClass());
+      log.debug("Found a Metrics Factory service: {}", metricsFactory.getClass());
       return metricsFactory;
     }
 

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
@@ -58,24 +58,24 @@ import java.util.Properties;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
-@ToString(exclude = {"registry", "clock", "metrics", "scopeManager"})
+@ToString
 @Slf4j
 public class JaegerTracer implements Tracer, Closeable {
-
   private final String version;
   private final String serviceName;
   private final Reporter reporter;
   private final Sampler sampler;
-  private final PropagationRegistry registry;
-  private final Clock clock;
-  private final Metrics metrics;
-  private final int ipv4;
   private final Map<String, ?> tags;
   private final boolean zipkinSharedRpcSpan;
-  private final ScopeManager scopeManager;
-  private final BaggageSetter baggageSetter;
   private final boolean expandExceptionLogs;
-  private final JaegerObjectFactory objectFactory;
+
+  @ToString.Exclude private final PropagationRegistry registry;
+  @ToString.Exclude private final Clock clock;
+  @ToString.Exclude private final Metrics metrics;
+  @ToString.Exclude private final ScopeManager scopeManager;
+  @ToString.Exclude private final BaggageSetter baggageSetter;
+  @ToString.Exclude private final JaegerObjectFactory objectFactory;
+  @ToString.Exclude private final int ipv4; // human readable representation is present within the tag map
 
   protected JaegerTracer(JaegerTracer.Builder builder) {
     this.serviceName = builder.serviceName;

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/reporters/RemoteReporter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/reporters/RemoteReporter.java
@@ -32,20 +32,22 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * RemoteReporter buffers spans in memory and sends them out of process using Sender.
  */
-@ToString(exclude = {"commandQueue", "flushTimer", "queueProcessorThread", "metrics"})
+@ToString
 @Slf4j
 public class RemoteReporter implements Reporter {
+  private static final int DEFAULT_CLOSE_ENQUEUE_TIMEOUT_MILLIS = 1000;
+
   public static final int DEFAULT_FLUSH_INTERVAL_MS = 1000;
   public static final int DEFAULT_MAX_QUEUE_SIZE = 100;
 
-  private static final int DEFAULT_CLOSE_ENQUEUE_TIMEOUT_MILLIS = 1000;
-  private final BlockingQueue<Command> commandQueue;
-  private final Timer flushTimer;
-  private final Thread queueProcessorThread;
-  private final QueueProcessor queueProcessor;
   private final Sender sender;
   private final int closeEnqueueTimeout;
-  private final Metrics metrics;
+
+  @ToString.Exclude private final BlockingQueue<Command> commandQueue;
+  @ToString.Exclude private final Timer flushTimer;
+  @ToString.Exclude private final Thread queueProcessorThread;
+  @ToString.Exclude private final QueueProcessor queueProcessor;
+  @ToString.Exclude private final Metrics metrics;
 
   private RemoteReporter(Sender sender, int flushInterval, int maxQueueSize, int closeEnqueueTimeout,
       Metrics metrics) {

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/HttpSamplingManager.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/HttpSamplingManager.java
@@ -26,11 +26,12 @@ import java.net.URLEncoder;
 import lombok.ToString;
 
 
-@ToString(exclude = "gson")
+@ToString
 public class HttpSamplingManager implements SamplingManager {
   public static final String DEFAULT_HOST_PORT = "localhost:5778";
-  private final Gson gson = new Gson();
   private final String hostPort;
+
+  @ToString.Exclude private final Gson gson = new Gson();
 
   /**
    * This constructor expects running sampling manager on {@link #DEFAULT_HOST_PORT}.

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/ProbabilisticSampler.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/ProbabilisticSampler.java
@@ -28,10 +28,12 @@ public class ProbabilisticSampler implements Sampler {
   public static final double DEFAULT_SAMPLING_PROBABILITY = 0.001;
   public static final String TYPE = "probabilistic";
 
-  private final long positiveSamplingBoundary;
-  private final long negativeSamplingBoundary;
-  @Getter private final double samplingRate;
   private final Map<String, Object> tags;
+
+  // exclude from toString as these are represented in the tags map already
+  @ToString.Exclude private final long positiveSamplingBoundary;
+  @ToString.Exclude private final long negativeSamplingBoundary;
+  @ToString.Exclude @Getter private final double samplingRate;
 
   public ProbabilisticSampler(double samplingRate) {
     if (samplingRate < 0.0 || samplingRate > 1.0) {

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/RateLimitingSampler.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/RateLimitingSampler.java
@@ -24,14 +24,15 @@ import lombok.Getter;
 import lombok.ToString;
 
 @SuppressWarnings("EqualsHashCode")
-@ToString(exclude = "rateLimiter")
+@ToString
 public class RateLimitingSampler implements Sampler {
   public static final String TYPE = "ratelimiting";
 
-  private final RateLimiter rateLimiter;
   @Getter
   private final double maxTracesPerSecond;
   private final Map<String, Object> tags;
+
+  @ToString.Exclude private final RateLimiter rateLimiter;
 
   public RateLimitingSampler(double maxTracesPerSecond) {
     this.maxTracesPerSecond = maxTracesPerSecond;

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/RemoteControlledSampler.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/RemoteControlledSampler.java
@@ -32,20 +32,24 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 @SuppressWarnings("EqualsHashCode")
-@ToString(exclude = {"pollTimer", "lock"})
+@ToString
 @Slf4j
 public class RemoteControlledSampler implements Sampler {
   public static final String TYPE = "remote";
   private static final int DEFAULT_POLLING_INTERVAL_MS = 60000;
 
   private final int maxOperations = 2000;
-  private final String serviceName;
   private final SamplingManager manager;
-  private final Timer pollTimer;
-  private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-  private final Metrics metrics;
+
   @Getter(AccessLevel.PACKAGE)
   private Sampler sampler;
+
+  // most of the time, toString here is called from the JaegerTracer, which holds this as well
+  @ToString.Exclude private final String serviceName;
+
+  @ToString.Exclude private final Timer pollTimer;
+  @ToString.Exclude private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+  @ToString.Exclude private final Metrics metrics;
 
   private RemoteControlledSampler(Builder builder) {
     this.serviceName = builder.serviceName;

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/senders/SenderResolver.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/senders/SenderResolver.java
@@ -69,7 +69,7 @@ public class SenderResolver {
         // factory the user wants:
         String requestedFactory = System.getProperty(Configuration.JAEGER_SENDER_FACTORY);
         if (senderFactory.getType().equals(requestedFactory)) {
-          log.info(
+          log.debug(
               String.format("Found the requested (%s) sender factory: %s",
                   requestedFactory,
                   senderFactory)
@@ -83,7 +83,7 @@ public class SenderResolver {
     }
 
     if (null != sender) {
-      log.info(String.format("Using sender %s", sender));
+      log.debug(String.format("Using sender %s", sender));
       return sender;
     } else {
       log.warn("No suitable sender found. Using NoopSender, meaning that data will not be sent anywhere!");

--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/reporters/protocols/ThriftUdpTransport.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/reporters/protocols/ThriftUdpTransport.java
@@ -29,15 +29,16 @@ import org.apache.thrift.transport.TTransportException;
 /*
  * A thrift transport for sending sending/receiving spans.
  */
-@ToString(exclude = {"writeBuffer"})
+@ToString
 public class ThriftUdpTransport extends TTransport implements Closeable {
   public static final int MAX_PACKET_SIZE = 65000;
 
-  public final DatagramSocket socket;
-  public byte[] receiveBuf;
   public int receiveOffSet = -1;
   public int receiveLength = 0;
-  public ByteBuffer writeBuffer;
+
+  @ToString.Exclude public final DatagramSocket socket;
+  @ToString.Exclude public byte[] receiveBuf;
+  @ToString.Exclude public ByteBuffer writeBuffer;
 
   // Create a UDP client for sending data to specific host and port
   public static ThriftUdpTransport newThriftUdpClient(String host, int port) {

--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/HttpSender.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/HttpSender.java
@@ -30,13 +30,14 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
-@ToString(exclude = {"httpClient", "requestBuilder"})
+@ToString
 public class HttpSender extends ThriftSender {
   private static final String HTTP_COLLECTOR_JAEGER_THRIFT_FORMAT_PARAM = "format=jaeger.thrift";
   private static final int ONE_MB_IN_BYTES = 1048576;
   private static final MediaType MEDIA_TYPE_THRIFT = MediaType.parse("application/x-thrift");
-  private final OkHttpClient httpClient;
-  private final Request.Builder requestBuilder;
+
+  @ToString.Exclude private final OkHttpClient httpClient;
+  @ToString.Exclude private final Request.Builder requestBuilder;
 
   protected HttpSender(Builder builder) {
     super(ProtocolType.Binary, builder.maxPacketSize);

--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/ThriftSender.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/ThriftSender.java
@@ -24,13 +24,14 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.ToString;
 
-@ToString(exclude = {"spanBuffer"})
+@ToString
 public abstract class ThriftSender extends ThriftSenderBase implements Sender {
 
   private Process process;
   private int processBytesSize;
-  private List<io.jaegertracing.thriftjava.Span> spanBuffer;
   private int byteBufferSize;
+
+  @ToString.Exclude private List<io.jaegertracing.thriftjava.Span> spanBuffer;
 
   /**
    * @param protocolType protocol type (compact or binary)

--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/ThriftSenderBase.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/ThriftSenderBase.java
@@ -24,7 +24,7 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.transport.AutoExpandingBufferWriteTransport;
 
-@ToString(exclude = {"memoryTransport"})
+@ToString
 @Slf4j
 public abstract class ThriftSenderBase {
 
@@ -35,11 +35,11 @@ public abstract class ThriftSenderBase {
 
   public static final int EMIT_BATCH_OVERHEAD = 33;
 
-  private AutoExpandingBufferWriteTransport memoryTransport;
-
   protected final TProtocolFactory protocolFactory;
   private final TSerializer serializer;
   private final int maxSpanBytes;
+
+  @ToString.Exclude private AutoExpandingBufferWriteTransport memoryTransport;
 
   /**
    * @param protocolType protocol type (compact or binary)

--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/UdpSender.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/UdpSender.java
@@ -22,13 +22,13 @@ import io.jaegertracing.thriftjava.Process;
 import java.util.List;
 import lombok.ToString;
 
-@ToString(exclude = {"agentClient"})
+@ToString
 public class UdpSender extends ThriftSender {
   public static final String DEFAULT_AGENT_UDP_HOST = "localhost";
   public static final int DEFAULT_AGENT_UDP_COMPACT_PORT = 6831;
 
-  private Agent.Client agentClient;
-  private ThriftUdpTransport udpTransport;
+  @ToString.Exclude private Agent.Client agentClient;
+  @ToString.Exclude private ThriftUdpTransport udpTransport;
 
   /**
    * This constructor expects Jaeger running running on {@value #DEFAULT_AGENT_UDP_HOST}

--- a/jaeger-zipkin/src/main/java/io/jaegertracing/zipkin/ZipkinSender.java
+++ b/jaeger-zipkin/src/main/java/io/jaegertracing/zipkin/ZipkinSender.java
@@ -57,10 +57,15 @@ import zipkin2.reporter.urlconnection.URLConnectionSender;
  * <p>
  * See https://github.com/openzipkin/zipkin/tree/master/zipkin-server
  */
-@ToString(exclude = {"spanBuffer", "encoder"})
+@ToString
 public final class ZipkinSender implements Sender {
   static final Set<String> CORE_ANNOTATIONS = new LinkedHashSet<String>(
       Arrays.asList(CLIENT_SEND, CLIENT_RECV, SERVER_SEND, SERVER_RECV));
+
+  final zipkin2.reporter.Sender delegate;
+
+  @ToString.Exclude final ThriftSpanEncoder encoder = new ThriftSpanEncoder();
+  @ToString.Exclude final List<byte[]> spanBuffer;
 
   /**
    * @param endpoint The POST URL for zipkin's <a href="http://zipkin.io/zipkin-api/#/">v1 api</a>,
@@ -97,10 +102,6 @@ public final class ZipkinSender implements Sender {
     }
     return new ZipkinSender(delegate);
   }
-
-  final ThriftSpanEncoder encoder = new ThriftSpanEncoder();
-  final zipkin2.reporter.Sender delegate;
-  final List<byte[]> spanBuffer;
 
   ZipkinSender(zipkin2.reporter.Sender delegate) {
     this.delegate = delegate;


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- The Jaeger Java Client is quite verbose during the bootstrap:

```
15:56:05,271 INFO  [io.jaegertracing.internal.senders.SenderResolver] (ServerService Thread Pool -- 7) Using sender UdpSender(udpTransport=ThriftUdpTransport(socket=java.net.DatagramSocket@c90e6f0, receiveBuf=null, receiveOffSet=-1, receiveLength=0))
15:56:05,452 INFO  [io.jaegertracing.Configuration] (ServerService Thread Pool -- 7) Initialized tracer=JaegerTracer(version=Java-0.30.5, serviceName=8dbe9483-4f76-42e9-8fcd-05421892257f.war, reporter=RemoteReporter(queueProcessor=RemoteReporter.QueueProcessor(open=true), sender=UdpSender(udpTransport=ThriftUdpTransport(socket=java.net.DatagramSocket@c90e6f0, receiveBuf=null, receiveOffSet=-1, receiveLength=0)), closeEnqueueTimeout=1000), sampler=RemoteControlledSampler(maxOperations=2000, serviceName=8dbe9483-4f76-42e9-8fcd-05421892257f.war, manager=HttpSamplingManager(hostPort=localhost:5778), metrics=io.jaegertracing.internal.metrics.Metrics@42ae2e51, sampler=ProbabilisticSampler(positiveSamplingBoundary=9223372036854776, negativeSamplingBoundary=-9223372036854776, samplingRate=0.001, tags={sampler.type=probabilistic, sampler.param=0.001})), ipv4=-1062731769, tags={hostname=caju.kroehling.de, jaeger.version=Java-0.30.5, ip=192.168.0.7}, zipkinSharedRpcSpan=false, baggageSetter=io.jaegertracing.internal.baggage.BaggageSetter@2d728fb9, expandExceptionLogs=false, objectFactory=io.jaegertracing.internal.JaegerObjectFactory@20cecb76)
```

## Short description of the changes
- Downgraded regular, non-exceptional messages to `debug` from `info` level. Users who wish to see those messages can set log4j to display `debug` messages for `io.jaegertracing` classes.
- Changed ToString annotation to not use exclusions at this annotation level, but rather, at the field level, so that future changes are more conscious about the fact that new properties end up in the `#toString()`