### PR TITLE
Add specification version to jars, and impl-title/version & spec vers…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,9 +74,6 @@ subprojects {
 
     jar {
         from sourceSets.main.output
-        manifest {
-            attributes('Implementation-Title': project.name, 'Implementation-Version': project.version, 'Specification-Version': project.version)
-        }
     }
 
     if (!version.endsWith("SNAPSHOT")) {
@@ -191,6 +188,11 @@ configure(subprojects.findAll {it.name != 'jaeger-thrift'}) {
     tasks.withType(JavaCompile) {
         // These are disabled because of a bug with errorprone. See https://github.com/google/error-prone/issues/750
         options.compilerArgs += [ '-Xep:NestedInstanceOfConditions:OFF',  '-Xep:InstanceOfAndCastMatchWrongType:OFF' ]
+    }
+    tasks.withType(Jar) {
+        manifest {
+            attributes('Implementation-Title': project.name, 'Implementation-Version': project.version, 'Specification-Version': project.version)
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ subprojects {
     jar {
         from sourceSets.main.output
         manifest {
-            attributes('Implementation-Title': project.name, 'Implementation-Version': project.version)
+            attributes('Implementation-Title': project.name, 'Implementation-Version': project.version, 'Specification-Version': project.version)
         }
     }
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,5 +1,11 @@
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
+ext.sharedManifest = manifest {
+    attributes("Implementation-Title": project.name,
+               "Implementation-Version": project.version,
+               "Specification-Version": project.version)
+}
+
 def getRepositoryUsername() {
     return hasProperty('ossrhUsername') ? ossrhUsername : ""
 }
@@ -65,8 +71,8 @@ uploadArchives {
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir
-    manifest {
-        attributes('Implementation-Title': project.name, 'Implementation-Version': project.version, 'Specification-Version': project.version)
+    manifest = project.manifest {
+        from sharedManifest
     }
 }
 
@@ -74,8 +80,8 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 task sourcesJar(type: Jar) {
     classifier = 'sources'
     from sourceSets.main.allSource
-    manifest {
-        attributes('Implementation-Title': project.name, 'Implementation-Version': project.version, 'Specification-Version': project.version)
+    manifest = project.manifest {
+        from sharedManifest
     }
 }
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -1,11 +1,5 @@
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
-ext.sharedManifest = manifest {
-    attributes("Implementation-Title": project.name,
-               "Implementation-Version": project.version,
-               "Specification-Version": project.version)
-}
-
 def getRepositoryUsername() {
     return hasProperty('ossrhUsername') ? ossrhUsername : ""
 }
@@ -71,18 +65,12 @@ uploadArchives {
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir
-    manifest = project.manifest {
-        from sharedManifest
-    }
 }
 
 // add sources to our jar
 task sourcesJar(type: Jar) {
     classifier = 'sources'
     from sourceSets.main.allSource
-    manifest = project.manifest {
-        from sharedManifest
-    }
 }
 
 // add the jars as artifacts

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -65,12 +65,18 @@ uploadArchives {
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir
+    manifest {
+        attributes('Implementation-Title': project.name, 'Implementation-Version': project.version, 'Specification-Version': project.version)
+    }
 }
 
 // add sources to our jar
 task sourcesJar(type: Jar) {
     classifier = 'sources'
     from sourceSets.main.allSource
+    manifest {
+        attributes('Implementation-Title': project.name, 'Implementation-Version': project.version, 'Specification-Version': project.version)
+    }
 }
 
 // add the jars as artifacts


### PR DESCRIPTION
…ion to javadoc and sources jars

Signed-off-by: Gary Brown <gary@brownuk.com>

## Which problem is this PR solving?
Adding missing manifest information to the jars (main, javadoc and source).

## Short description of the changes
Make sure `Implementation-Title`, `Implementation-Version` and `Specification-Version` are applied to all three jars for each module.
