### PR TITLE
Close tracer on JVM shutdown

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
@@ -120,6 +120,14 @@ public class JaegerTracer implements Tracer, Closeable {
     }
     this.ipv4 = ipv4;
     this.tags = Collections.unmodifiableMap(tags);
+
+    // register this tracer with a shutdown hook, to flush the spans before the VM shuts down
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      public void run() {
+        JaegerTracer.this.close();
+      }
+    });
   }
 
   public String getVersion() {


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

## Which problem is this PR solving?
- Resolves #544

## Short description of the changes
- Adds a shutdown hook to close the tracer before the JVM dies. I tested this with the same code as the reporter. When running the code *without* an explicit `tracer.close()`, I see this in the logs for the client:

```
12:35:51.066 [main] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: f9e218d52dc14279:f9e218d52dc14279:0:1 - say-hello
```

But nothing on the server side. Starting an all-in-one container with `--log-level=debug` confirms that nothing is received on that end.

With this PR applied, I do see the trace:

```
12:40:39.544 [main] INFO io.jaegertracing.internal.reporters.LoggingReporter - Span reported: 3ce5effda0536731:3ce5effda0536731:0:1 - say-hello
```

And on the server side: 

```json
{"level":"debug","ts":1536316839.6288192,"caller":"app/span_processor.go:104","msg":"Span written to the storage by the collector","trace-id":"3ce5effda0536731","span-id":"3ce5effda0536731"}
```
