### PR TITLE
Report java version as process tag

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/Constants.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/Constants.java
@@ -50,6 +50,11 @@ public class Constants {
   public static final String JAEGER_CLIENT_VERSION_TAG_KEY = "jaeger.version";
 
   /**
+   * The name of the tag used to report java version.
+   */
+  public static final String JAVA_VERSION_TAG_KEY = "java.version";
+
+  /**
    * The name used to report host name of the process.
    */
   public static final String TRACER_HOSTNAME_TAG_KEY = "hostname";

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
@@ -94,6 +94,7 @@ public class JaegerTracer implements Tracer, Closeable {
 
     Map<String, Object> tags = new HashMap<String, Object>(builder.tags);
     tags.put(Constants.JAEGER_CLIENT_VERSION_TAG_KEY, this.version);
+    tags.put(Constants.JAVA_VERSION_TAG_KEY, System.getProperty(Constants.JAVA_VERSION_TAG_KEY));
     if (tags.get(Constants.TRACER_HOSTNAME_TAG_KEY) == null) {
       String hostname = getHostName();
       if (hostname != null) {


### PR DESCRIPTION
In a large organization, there is numbers of services deployed base on different version jdk, Java version should be collected as built-in tag. 
It's better jaeger spark job and ui can provide a list view for specified tag (here is java.version), something like:

| Service  | Tag (java.version) |
| ------------- | ------------- |
| A | 1.8.0_181  |
| B | 1.8.0_181  |
| C | 9  |
| D | 10.0.2  |