### PR TITLE
Allow parsing configuration codec string programatically

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
@@ -414,11 +414,6 @@ public class Configuration {
       codecs = new HashMap<Format<?>, List<Codec<TextMap>>>();
     }
 
-
-    private CodecConfiguration(Map<Format<?>, List<Codec<TextMap>>> codecs) {
-      this.codecs = codecs;
-    }
-
     public static CodecConfiguration fromEnv() {
       return fromString(getProperty(JAEGER_PROPAGATION));
     }
@@ -429,29 +424,33 @@ public class Configuration {
      * @return codec configuration
      */
     public static CodecConfiguration fromString(String propagation) {
-      Map<Format<?>, List<Codec<TextMap>>> codecs = new HashMap<Format<?>, List<Codec<TextMap>>>();
+      CodecConfiguration codecConfiguration = new CodecConfiguration();
       if (propagation != null) {
         for (String format : Arrays.asList(propagation.split(","))) {
           try {
-            switch (Configuration.Propagation.valueOf(format.toUpperCase())) {
-              case JAEGER:
-                addCodec(codecs, Format.Builtin.HTTP_HEADERS, new TextMapCodec(true));
-                addCodec(codecs, Format.Builtin.TEXT_MAP, new TextMapCodec(false));
-                break;
-              case B3:
-                addCodec(codecs, Format.Builtin.HTTP_HEADERS, new B3TextMapCodec.Builder().build());
-                addCodec(codecs, Format.Builtin.TEXT_MAP, new B3TextMapCodec.Builder().build());
-                break;
-              default:
-                log.error("Unhandled propagation format '" + format + "'");
-                break;
-            }
+            codecConfiguration.withPropagation(Configuration.Propagation.valueOf(format.toUpperCase()));
           } catch (IllegalArgumentException iae) {
             log.error("Unknown propagation format '" + format + "'");
           }
         }
       }
-      return new CodecConfiguration(codecs);
+      return codecConfiguration;
+    }
+
+    public CodecConfiguration withPropagation(Propagation propagation) {
+      switch (propagation) {
+        case JAEGER:
+          addCodec(codecs, Format.Builtin.HTTP_HEADERS, new TextMapCodec(true));
+          addCodec(codecs, Format.Builtin.TEXT_MAP, new TextMapCodec(false));
+          break;
+        case B3:
+          addCodec(codecs, Format.Builtin.HTTP_HEADERS, new B3TextMapCodec.Builder().build());
+          addCodec(codecs, Format.Builtin.TEXT_MAP, new B3TextMapCodec.Builder().build());
+          break;
+        default:
+          log.error("Unhandled propagation format '" + propagation + "'");
+      }
+      return this;
     }
 
     public CodecConfiguration withCodec(Format<?> format, Codec<TextMap> codec) {

--- a/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
@@ -420,8 +420,16 @@ public class Configuration {
     }
 
     public static CodecConfiguration fromEnv() {
+      return fromString(getProperty(JAEGER_PROPAGATION));
+    }
+
+    /**
+     * Parse codecs/propagation from string
+     * @param propagation string containing a coma separated list of propagations {@link Propagation}.
+     * @return codec configuration
+     */
+    public static CodecConfiguration fromString(String propagation) {
       Map<Format<?>, List<Codec<TextMap>>> codecs = new HashMap<Format<?>, List<Codec<TextMap>>>();
-      String propagation = getProperty(JAEGER_PROPAGATION);
       if (propagation != null) {
         for (String format : Arrays.asList(propagation.split(","))) {
           try {

--- a/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import io.jaegertracing.Configuration.CodecConfiguration;
+import io.jaegertracing.Configuration.Propagation;
 import io.jaegertracing.Configuration.ReporterConfiguration;
 import io.jaegertracing.Configuration.SamplerConfiguration;
 import io.jaegertracing.internal.JaegerSpanContext;
@@ -28,6 +29,8 @@ import io.jaegertracing.internal.JaegerTracer;
 import io.jaegertracing.internal.metrics.InMemoryMetricsFactory;
 import io.jaegertracing.internal.metrics.Metrics;
 import io.jaegertracing.internal.metrics.MockMetricsFactory;
+import io.jaegertracing.internal.propagation.B3TextMapCodec;
+import io.jaegertracing.internal.propagation.TextMapCodec;
 import io.jaegertracing.internal.samplers.ConstSampler;
 import io.jaegertracing.internal.samplers.ProbabilisticSampler;
 import io.jaegertracing.internal.samplers.RateLimitingSampler;
@@ -374,6 +377,19 @@ public class ConfigurationTest {
     assertInjectExtract(configuration.getTracer(), Builtin.HTTP_HEADERS, spanContext, false);
   }
 
+  @Test
+  public void testCodecFromString() {
+    CodecConfiguration codecConfiguration = CodecConfiguration
+        .fromString(String.format("%s,%s", Propagation.B3.name(), Propagation.JAEGER.name()));
+    assertEquals(2, codecConfiguration.getCodecs().size());
+    assertEquals(2, codecConfiguration.getCodecs().get(Builtin.HTTP_HEADERS).size());
+    assertEquals(2, codecConfiguration.getCodecs().get(Builtin.TEXT_MAP).size());
+    assertTrue(codecConfiguration.getCodecs().get(Builtin.HTTP_HEADERS).get(0) instanceof B3TextMapCodec);
+    assertTrue(codecConfiguration.getCodecs().get(Builtin.HTTP_HEADERS).get(1) instanceof TextMapCodec);
+    assertTrue(codecConfiguration.getCodecs().get(Builtin.TEXT_MAP).get(0) instanceof B3TextMapCodec);
+    assertTrue(codecConfiguration.getCodecs().get(Builtin.TEXT_MAP).get(1) instanceof TextMapCodec);
+  }
+
   @SuppressWarnings("unchecked")
   private <C> void assertInjectExtract(JaegerTracer tracer, Format<C> format, JaegerSpanContext contextToInject,
                                        boolean injectMapIsEmpty) {
@@ -416,4 +432,5 @@ public class ConfigurationTest {
       return values.get(key);
     }
   }
+
 }

--- a/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
@@ -390,6 +390,28 @@ public class ConfigurationTest {
     assertTrue(codecConfiguration.getCodecs().get(Builtin.TEXT_MAP).get(1) instanceof TextMapCodec);
   }
 
+  @Test
+  public void testCodecWithPropagationJaeger() {
+    CodecConfiguration codecConfiguration = new CodecConfiguration()
+        .withPropagation(Propagation.JAEGER);
+    assertEquals(2, codecConfiguration.getCodecs().size());
+    assertEquals(1, codecConfiguration.getCodecs().get(Builtin.HTTP_HEADERS).size());
+    assertEquals(1, codecConfiguration.getCodecs().get(Builtin.TEXT_MAP).size());
+    assertTrue(codecConfiguration.getCodecs().get(Builtin.HTTP_HEADERS).get(0) instanceof TextMapCodec);
+    assertTrue(codecConfiguration.getCodecs().get(Builtin.TEXT_MAP).get(0) instanceof TextMapCodec);
+  }
+
+  @Test
+  public void testCodecWithPropagationB3() {
+    CodecConfiguration codecConfiguration = new CodecConfiguration()
+        .withPropagation(Propagation.B3);
+    assertEquals(2, codecConfiguration.getCodecs().size());
+    assertEquals(1, codecConfiguration.getCodecs().get(Builtin.HTTP_HEADERS).size());
+    assertEquals(1, codecConfiguration.getCodecs().get(Builtin.TEXT_MAP).size());
+    assertTrue(codecConfiguration.getCodecs().get(Builtin.HTTP_HEADERS).get(0) instanceof B3TextMapCodec);
+    assertTrue(codecConfiguration.getCodecs().get(Builtin.TEXT_MAP).get(0) instanceof B3TextMapCodec);
+  }
+
   @SuppressWarnings("unchecked")
   private <C> void assertInjectExtract(JaegerTracer tracer, Format<C> format, JaegerSpanContext contextToInject,
                                        boolean injectMapIsEmpty) {


### PR DESCRIPTION
For example It's needed if the configuration is provided via
runtime specific means - e.g. conf file.


