### PR TITLE
Resolve conflict between withStartTimestamp and computeDurationViaNan…

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
@@ -429,10 +429,10 @@ public class JaegerTracer implements Tracer, Closeable {
 
       if (startTimeMicroseconds == 0) {
         startTimeMicroseconds = clock.currentTimeMicros();
-        if (!clock.isMicrosAccurate()) {
+	  }
+      if (!clock.isMicrosAccurate()) {
           startTimeNanoTicks = clock.currentNanoTicks();
           computeDurationViaNanoTicks = true;
-        }
       }
 
       JaegerSpan jaegerSpan = getObjectFactory().createSpan(


### PR DESCRIPTION
…oTicks

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
-#545

## Short description of the changes
-set computeDurationViaNanoTicks independently
