### PR TITLE
Introduce JAEGER_CONFIG_MANAGER_ENDPOINT property

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/HttpSamplingManager.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/HttpSamplingManager.java
@@ -28,20 +28,23 @@ import lombok.ToString;
 
 @ToString
 public class HttpSamplingManager implements SamplingManager {
-  public static final String DEFAULT_HOST_PORT = "localhost:5778";
-  private final String hostPort;
+  public static final String DEFAULT_SERVER_HOST = "localhost";
+  public static final int DEFAULT_SERVER_PORT = 5778;
+  public static final String DEFAULT_SERVER_URL =
+          "http://" + DEFAULT_SERVER_HOST + ":" + DEFAULT_SERVER_PORT + "/sampling";
+  private final String serverUrl;
 
   @ToString.Exclude private final Gson gson = new Gson();
 
   /**
-   * This constructor expects running sampling manager on {@link #DEFAULT_HOST_PORT}.
+   * This constructor expects running sampling manager on {@link #DEFAULT_SERVER_URL}.
    */
   public HttpSamplingManager() {
-    this(DEFAULT_HOST_PORT);
+    this(DEFAULT_SERVER_URL);
   }
 
-  public HttpSamplingManager(String hostPort) {
-    this.hostPort = hostPort != null ? hostPort : DEFAULT_HOST_PORT;
+  public HttpSamplingManager(String serverUrl) {
+    this.serverUrl = serverUrl != null ? serverUrl : DEFAULT_SERVER_URL;
   }
 
   SamplingStrategyResponse parseJson(String json) {
@@ -59,7 +62,7 @@ public class HttpSamplingManager implements SamplingManager {
     try {
       jsonString =
           makeGetRequest(
-              "http://" + hostPort + "/?service=" + URLEncoder.encode(serviceName, "UTF-8"));
+              serverUrl + "?service=" + URLEncoder.encode(serviceName, "UTF-8"));
     } catch (IOException e) {
       throw new SamplingStrategyErrorException(
           "http call to get sampling strategy from local agent failed.", e);

--- a/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
@@ -62,6 +62,7 @@ public class ConfigurationTest {
     System.clearProperty(Configuration.JAEGER_SAMPLER_TYPE);
     System.clearProperty(Configuration.JAEGER_SAMPLER_PARAM);
     System.clearProperty(Configuration.JAEGER_SAMPLER_MANAGER_HOST_PORT);
+    System.clearProperty(Configuration.JAEGER_CONFIG_MANAGER_ENDPOINT);
     System.clearProperty(Configuration.JAEGER_SERVICE_NAME);
     System.clearProperty(Configuration.JAEGER_TAGS);
     System.clearProperty(Configuration.JAEGER_ENDPOINT);
@@ -108,6 +109,42 @@ public class ConfigurationTest {
     SamplerConfiguration samplerConfig = SamplerConfiguration.fromEnv();
     assertEquals(ConstSampler.TYPE, samplerConfig.getType());
     assertNull(samplerConfig.getParam());
+  }
+
+  @Test
+  public void testConfigManagerUrl() {
+    System.setProperty(Configuration.JAEGER_CONFIG_MANAGER_ENDPOINT, "http://example.com/sampling");
+    SamplerConfiguration samplerConfig = SamplerConfiguration.fromEnv();
+    assertEquals("http://example.com/sampling", samplerConfig.getServerUrl());
+  }
+
+  @Test
+  public void testConfigManagerUrlOverridesSamplerManagerHostPort() {
+    System.setProperty(Configuration.JAEGER_CONFIG_MANAGER_ENDPOINT, "http://example.com/sampling");
+    System.setProperty(Configuration.JAEGER_SAMPLER_MANAGER_HOST_PORT, "example.org:80");
+    SamplerConfiguration samplerConfig = SamplerConfiguration.fromEnv();
+    assertEquals("http://example.com/sampling", samplerConfig.getServerUrl());
+  }
+
+  @Test
+  public void testSamplerManagerHostPortOverridesAgentHost() {
+    System.setProperty(Configuration.JAEGER_SAMPLER_MANAGER_HOST_PORT, "example.org:80");
+    System.setProperty(Configuration.JAEGER_AGENT_HOST, "example.com");
+    SamplerConfiguration samplerConfig = SamplerConfiguration.fromEnv();
+    assertEquals("http://example.org:80/sampling", samplerConfig.getServerUrl());
+  }
+
+  @Test
+  public void testAgentHostOverridesDefault() {
+    System.setProperty(Configuration.JAEGER_AGENT_HOST, "example.com");
+    SamplerConfiguration samplerConfig = SamplerConfiguration.fromEnv();
+    assertEquals("http://example.com:5778/sampling", samplerConfig.getServerUrl());
+  }
+
+  @Test
+  public void testSettingManagerHostPortProducesUrl() {
+    SamplerConfiguration samplerConfig = SamplerConfiguration.fromEnv().withManagerHostPort("example.com:80");
+    assertEquals("http://example.com:80/sampling", samplerConfig.getServerUrl());
   }
 
   @Test

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/samplers/HttpSamplingManagerTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/samplers/HttpSamplingManagerTest.java
@@ -67,7 +67,7 @@ public class HttpSamplingManagerTest extends JerseyTest {
   @Test
   public void testGetSamplingStrategy() throws Exception {
     URI uri = target().getUri();
-    undertest = new HttpSamplingManager(uri.getHost() + ":" + uri.getPort());
+    undertest = new HttpSamplingManager("http://" + uri.getHost() + ":" + uri.getPort());
     SamplingStrategyResponse response = undertest.getSamplingStrategy("clairvoyant");
     assertNotNull(response.getProbabilisticSampling());
   }


### PR DESCRIPTION
## Which problem is this PR solving?
- Issue https://github.com/jaegertracing/jaeger-client-java/issues/521
  - Rename `JAEGER_SAMPLER_MANAGER_HOST_PORT` to ` JAEGER_CONFIG_MGR_HOST_PORT`
- Issue https://github.com/jaegertracing/jaeger-client-java/issues/547
  - Fall back to JAEGER_AGENT_HOST for JAEGER_SAMPLER_MANAGER_HOST_PORT before localhost

## Short description of the changes

Introduce a new property, `JAEGER_CONFIG_MANAGER_ENDPOINT`, that should be set to the URL of the Jaeger Config Manager sampling endpoint. If not set, fall back to the now-deprecated `JAEGER_SAMPLER_MANAGER_HOST_PORT` as the host and port of the URL.

If `JAEGER_AGENT_HOST` has been set as a property, further fall back to that value as the host of the URL (using the default port of 5778).

This brings the `SamplerConfiguration` in-line with the Go client.

See also:
 * https://github.com/jaegertracing/jaeger-client-go/issues/326
 * https://github.com/jaegertracing/jaeger-client-go/issues/282

Note that this does remove `SampleConfiguration#getManagerHostPort()` - the alternative would be to try to parse the URI provided and return the derived host and port.  Thoughts?