### PR TITLE
Refer to valid `sampler type` values (doc link)

### DIFF
--- a/jaeger-core/README.md
+++ b/jaeger-core/README.md
@@ -86,7 +86,7 @@ JAEGER_PROPAGATION | no | Comma separated list of formats to use for propagating
 JAEGER_REPORTER_LOG_SPANS | no | Whether the reporter should also log the spans
 JAEGER_REPORTER_MAX_QUEUE_SIZE | no | The reporter's maximum queue size
 JAEGER_REPORTER_FLUSH_INTERVAL | no | The reporter's flush interval (ms)
-JAEGER_SAMPLER_TYPE | no | The sampler type
+JAEGER_SAMPLER_TYPE | no | The [sampler type](https://www.jaegertracing.io/docs/latest/sampling/#client-sampling-configuration)
 JAEGER_SAMPLER_PARAM | no | The sampler parameter (number)
 JAEGER_SAMPLER_MANAGER_HOST_PORT | no | The host name and port when using the remote controlled sampler
 JAEGER_TAGS | no | A comma separated list of `name = value` tracer level tags, which get added to all reported spans. The value can also refer to an environment variable using the format `${envVarName:default}`, where the `:default` is optional, and identifies a value to be used if the environment variable cannot be found


### PR DESCRIPTION
## Which problem is this PR solving?
- Make it easier to find the valid sampler types from the java client README

## Short description of the changes
- Link to jaeger documentation on client samling configuration.
