### PR TITLE
Remove nexus staging profile id

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,6 @@ subprojects {
             // Dealing with error "Wrong number of received repositories in state 'open'" (http://bit.ly/2ybracm)
             numberOfRetries = 50
             delayBetweenRetriesInMillis = 3000
-            stagingProfileId = "${getVersionForBuild().replaceAll("\\.|-", "")}-${System.currentTimeMillis()}".toString()
         }
 
         uploadArchives.finalizedBy closeAndReleaseRepository


### PR DESCRIPTION
Removing as it does not solve the issue with failing release process see https://github.com/jaegertracing/jaeger-client-java/issues/390#issuecomment-429867332

Signed-off-by: Pavol Loffay 🦄 <ploffay@redhat.com>

