### PR TITLE
Normalise metric names

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/metrics/Metrics.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/metrics/Metrics.java
@@ -25,10 +25,14 @@ import java.util.TreeMap;
 public class Metrics {
 
   public Metrics(MetricsFactory factory) {
-    createMetrics(factory);
+    this(factory, "jaeger_tracer_");
   }
 
-  private void createMetrics(MetricsFactory factory) {
+  public Metrics(MetricsFactory factory, String metricsPrefix) {
+    createMetrics(factory, metricsPrefix);
+  }
+
+  private void createMetrics(MetricsFactory factory, String metricsPrefix) {
     for (Field field : Metrics.class.getDeclaredFields()) {
       if (!Counter.class.isAssignableFrom(field.getType())
           && !Timer.class.isAssignableFrom(field.getType())
@@ -38,7 +42,7 @@ public class Metrics {
         continue;
       }
 
-      StringBuilder metricBuilder = new StringBuilder("jaeger:");
+      StringBuilder metricBuilder = new StringBuilder(metricsPrefix);
       HashMap<String, String> tags = new HashMap<String, String>();
 
       Annotation[] annotations = field.getAnnotations();

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSpanTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSpanTest.java
@@ -94,8 +94,8 @@ public class JaegerSpanTest {
 
   @Test
   public void testSpanMetrics() {
-    assertEquals(1, metricsFactory.getCounter("jaeger:started_spans", "sampled=y"));
-    assertEquals(1, metricsFactory.getCounter("jaeger:traces", "sampled=y,state=started"));
+    assertEquals(1, metricsFactory.getCounter("jaeger_tracer_started_spans", "sampled=y"));
+    assertEquals(1, metricsFactory.getCounter("jaeger_tracer_traces", "sampled=y,state=started"));
   }
 
   @Test

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerTracerTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerTracerTest.java
@@ -90,10 +90,10 @@ public class JaegerTracerTest {
   public void testTracerMetrics() {
     String expectedOperation = "fry";
     tracer.buildSpan(expectedOperation).start();
-    assertEquals(1, metricsFactory.getCounter("jaeger:started_spans", "sampled=y"));
-    assertEquals(0, metricsFactory.getCounter("jaeger:started_spans", "sampled=n"));
-    assertEquals(1, metricsFactory.getCounter("jaeger:traces", "sampled=y,state=started"));
-    assertEquals(0, metricsFactory.getCounter("jaeger:traces", "sampled=n,state=started"));
+    assertEquals(1, metricsFactory.getCounter("jaeger_tracer_started_spans", "sampled=y"));
+    assertEquals(0, metricsFactory.getCounter("jaeger_tracer_started_spans", "sampled=n"));
+    assertEquals(1, metricsFactory.getCounter("jaeger_tracer_traces", "sampled=y,state=started"));
+    assertEquals(0, metricsFactory.getCounter("jaeger_tracer_traces", "sampled=n,state=started"));
   }
 
   @Test
@@ -152,7 +152,7 @@ public class JaegerTracerTest {
     final String key = "key";
     tracer.setBaggage(span, key, "value");
 
-    assertEquals(1, metricsFactory.getCounter("jaeger:baggage_updates", "result=ok"));
+    assertEquals(1, metricsFactory.getCounter("jaeger_tracer_baggage_updates", "result=ok"));
   }
 
   @Test
@@ -179,9 +179,9 @@ public class JaegerTracerTest {
     JaegerSpan first = tracer.buildSpan(expectedOperation).start();
     tracer.buildSpan(expectedOperation).asChildOf((first.context()).withFlags((byte) 0)).start();
 
-    assertEquals(1, metricsFactory.getCounter("jaeger:started_spans", "sampled=y"));
-    assertEquals(1, metricsFactory.getCounter("jaeger:started_spans", "sampled=n"));
-    assertEquals(1, metricsFactory.getCounter("jaeger:traces", "sampled=y,state=started"));
-    assertEquals(0, metricsFactory.getCounter("jaeger:traces", "sampled=n,state=started"));
+    assertEquals(1, metricsFactory.getCounter("jaeger_tracer_started_spans", "sampled=y"));
+    assertEquals(1, metricsFactory.getCounter("jaeger_tracer_started_spans", "sampled=n"));
+    assertEquals(1, metricsFactory.getCounter("jaeger_tracer_traces", "sampled=y,state=started"));
+    assertEquals(0, metricsFactory.getCounter("jaeger_tracer_traces", "sampled=n,state=started"));
   }
 }

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/baggage/BaggageSetterTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/baggage/BaggageSetterTest.java
@@ -73,7 +73,7 @@ public class BaggageSetterTest {
     assertBaggageLogs(jaegerSpan, KEY, value, false, false, true);
     assertNull(ctx.getBaggageItem(KEY));
 
-    assertEquals(1, metricsFactory.getCounter("jaeger:baggage_updates", "result=err"));
+    assertEquals(1, metricsFactory.getCounter("jaeger_tracer_baggage_updates", "result=err"));
   }
 
   @Test
@@ -86,8 +86,8 @@ public class BaggageSetterTest {
     assertBaggageLogs(jaegerSpan, KEY, expected, true, false, false);
     assertEquals(expected, ctx.getBaggageItem(KEY));
 
-    assertEquals(1, metricsFactory.getCounter("jaeger:baggage_truncations", ""));
-    assertEquals(1, metricsFactory.getCounter("jaeger:baggage_updates", "result=ok"));
+    assertEquals(1, metricsFactory.getCounter("jaeger_tracer_baggage_truncations", ""));
+    assertEquals(1, metricsFactory.getCounter("jaeger_tracer_baggage_updates", "result=ok"));
   }
 
   @Test
@@ -101,7 +101,7 @@ public class BaggageSetterTest {
     assertBaggageLogs(child, KEY, value, false, true, false);
     assertEquals(value, ctx.getBaggageItem(KEY));
 
-    assertEquals(2, metricsFactory.getCounter("jaeger:baggage_updates", "result=ok"));
+    assertEquals(2, metricsFactory.getCounter("jaeger_tracer_baggage_updates", "result=ok"));
   }
 
   @Test
@@ -146,7 +146,7 @@ public class BaggageSetterTest {
     assertBaggageLogs(child, KEY, null, false, true, false);
     assertNull(child.getBaggageItem(KEY));
 
-    assertEquals(2, metricsFactory.getCounter("jaeger:baggage_updates", "result=ok"));
+    assertEquals(2, metricsFactory.getCounter("jaeger_tracer_baggage_updates", "result=ok"));
   }
 
   private void assertBaggageLogs(JaegerSpan jaegerSpan, String key, String value,

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/baggage/RemoteBaggageRestrictionManagerTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/baggage/RemoteBaggageRestrictionManagerTest.java
@@ -72,7 +72,7 @@ public class RemoteBaggageRestrictionManagerTest {
     assertEquals(Restriction.of(true, MAX_VALUE_LENGTH), undertest.getRestriction(SERVICE_NAME, BAGGAGE_KEY));
     assertFalse(undertest.getRestriction(SERVICE_NAME, "bad-key").isKeyAllowed());
     assertTrue(
-        metricsFactory.getCounter("jaeger:baggage_restrictions_updates.result=ok",
+        metricsFactory.getCounter("jaeger_tracer_baggage_restrictions_updates.result=ok",
             Collections.emptyMap()) > 0L);
   }
 
@@ -93,7 +93,7 @@ public class RemoteBaggageRestrictionManagerTest {
     assertFalse(undertest.isReady());
     // If baggage restriction update fails, all baggage should still be allowed.
     assertTrue(undertest.getRestriction(SERVICE_NAME, BAGGAGE_KEY).isKeyAllowed());
-    assertTrue(metricsFactory.getCounter("jaeger:baggage_restrictions_updates.result=err",
+    assertTrue(metricsFactory.getCounter("jaeger_tracer_baggage_restrictions_updates.result=err",
         Collections.emptyMap()) > 0L);
   }
 

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/metrics/InMemoryMetricsFactoryTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/metrics/InMemoryMetricsFactoryTest.java
@@ -109,8 +109,8 @@ public class InMemoryMetricsFactoryTest {
             .build();
 
     tracer.buildSpan("theoperation").start();
-    assertEquals(-1, metricsFactory.getCounter("jaeger:started_spans", "sampled"));
-    assertEquals(-1, metricsFactory.getCounter("jaeger:started_spans", ""));
+    assertEquals(-1, metricsFactory.getCounter("jaeger_tracer_started_spans", "sampled"));
+    assertEquals(-1, metricsFactory.getCounter("jaeger_tracer_started_spans", ""));
   }
 
   @Test
@@ -123,9 +123,9 @@ public class InMemoryMetricsFactoryTest {
             .build();
 
     tracer.buildSpan("theoperation").start();
-    assertEquals(1, metricsFactory.getCounter("jaeger:started_spans", "sampled=y"));
-    assertEquals(0, metricsFactory.getCounter("jaeger:started_spans", "sampled=n"));
-    assertEquals(1, metricsFactory.getCounter("jaeger:traces", "sampled=y,state=started"));
-    assertEquals(0, metricsFactory.getCounter("jaeger:traces", "sampled=n,state=started"));
+    assertEquals(1, metricsFactory.getCounter("jaeger_tracer_started_spans", "sampled=y"));
+    assertEquals(0, metricsFactory.getCounter("jaeger_tracer_started_spans", "sampled=n"));
+    assertEquals(1, metricsFactory.getCounter("jaeger_tracer_traces", "sampled=y,state=started"));
+    assertEquals(0, metricsFactory.getCounter("jaeger_tracer_traces", "sampled=n,state=started"));
   }
 }

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/metrics/MetricsTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/metrics/MetricsTest.java
@@ -34,13 +34,13 @@ public class MetricsTest {
   @Test
   public void testCounterWithoutExplicitTags() {
     metrics.tracesJoinedSampled.inc(1);
-    assertEquals(1, metricsFactory.getCounter("jaeger:traces", "sampled=y,state=joined"));
+    assertEquals(1, metricsFactory.getCounter("jaeger_tracer_traces", "sampled=y,state=joined"));
   }
 
   @Test
   public void testGaugeWithoutExplicitTags() {
     metrics.reporterQueueLength.update(1);
-    assertEquals(1, metricsFactory.getGauge("jaeger:reporter_queue_length", ""));
+    assertEquals(1, metricsFactory.getGauge("jaeger_tracer_reporter_queue_length", ""));
   }
 
   @Test
@@ -48,6 +48,14 @@ public class MetricsTest {
     Map<String, String> tags = new HashMap<>();
     tags.put("foo", "bar");
     assertEquals("thecounter.foo=bar", Metrics.addTagsToMetricName("thecounter", tags));
-    assertEquals("jaeger:thecounter.foo=bar", Metrics.addTagsToMetricName("jaeger:thecounter", tags));
+    assertEquals("jaeger_tracer_thecounter.foo=bar", Metrics.addTagsToMetricName("jaeger_tracer_thecounter", tags));
   }
+
+  @Test
+  public void testCounterWithCustomPrefix() {
+    Metrics customPrefixMetrics = new Metrics(metricsFactory, "custom_");
+    customPrefixMetrics.tracesJoinedSampled.inc(1);
+    assertEquals(1, metricsFactory.getCounter("custom_traces", "sampled=y,state=joined"));
+  }
+
 }

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/reporters/RemoteReporterTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/reporters/RemoteReporterTest.java
@@ -97,9 +97,9 @@ public class RemoteReporterTest {
     assertEquals(0, sender.getAppended().size());
     assertEquals(numberOfSpans, sender.getFlushed().size());
 
-    assertEquals(100, metricsFactory.getCounter("jaeger:started_spans", "sampled=y"));
-    assertEquals(100, metricsFactory.getCounter("jaeger:reporter_spans", "result=ok"));
-    assertEquals(100, metricsFactory.getCounter("jaeger:traces", "sampled=y,state=started"));
+    assertEquals(100, metricsFactory.getCounter("jaeger_tracer_started_spans", "sampled=y"));
+    assertEquals(100, metricsFactory.getCounter("jaeger_tracer_reporter_spans", "result=ok"));
+    assertEquals(100, metricsFactory.getCounter("jaeger_tracer_traces", "sampled=y,state=started"));
   }
 
   @Test
@@ -170,7 +170,7 @@ public class RemoteReporterTest {
     reporter.report(newSpan());
 
     // Then: one or both spans should be dropped
-    long droppedCount = metricsFactory.getCounter("jaeger:reporter_spans", "result=dropped");
+    long droppedCount = metricsFactory.getCounter("jaeger_tracer_reporter_spans", "result=dropped");
     assertThat(droppedCount, anyOf(equalTo(1L), equalTo(2L)));
   }
 
@@ -240,12 +240,12 @@ public class RemoteReporterTest {
       reporter.report(newSpan());
     }
 
-    assertEquals(0, metricsFactory.getGauge("jaeger:reporter_queue_length", ""));
+    assertEquals(0, metricsFactory.getGauge("jaeger_tracer_reporter_queue_length", ""));
 
     RemoteReporter remoteReporter = (RemoteReporter) reporter;
     remoteReporter.flush();
 
-    assertTrue(metricsFactory.getGauge("jaeger:reporter_queue_length", "") > 0);
+    assertTrue(metricsFactory.getGauge("jaeger_tracer_reporter_queue_length", "") > 0);
   }
 
   @Test

--- a/jaeger-micrometer/src/test/java/io/jaegertracing/micrometer/MicrometerTest.java
+++ b/jaeger-micrometer/src/test/java/io/jaegertracing/micrometer/MicrometerTest.java
@@ -54,17 +54,17 @@ public class MicrometerTest {
 
   @BeforeClass
   public static void initial() {
-    expectedMetricCounts.put("jaeger:sampler_updates", 2L);
-    expectedMetricCounts.put("jaeger:finished_spans", 1L);
-    expectedMetricCounts.put("jaeger:baggage_restrictions_updates", 2L);
-    expectedMetricCounts.put("jaeger:started_spans", 2L);
-    expectedMetricCounts.put("jaeger:baggage_updates", 2L);
-    expectedMetricCounts.put("jaeger:sampler_queries", 2L);
-    expectedMetricCounts.put("jaeger:baggage_truncations", 1L);
-    expectedMetricCounts.put("jaeger:reporter_spans", 3L);
-    expectedMetricCounts.put("jaeger:traces", 4L);
-    expectedMetricCounts.put("jaeger:span_context_decoding_errors", 1L);
-    expectedMetricCounts.put("jaeger:reporter_queue_length", 1L);
+    expectedMetricCounts.put("jaeger_tracer_sampler_updates", 2L);
+    expectedMetricCounts.put("jaeger_tracer_finished_spans", 1L);
+    expectedMetricCounts.put("jaeger_tracer_baggage_restrictions_updates", 2L);
+    expectedMetricCounts.put("jaeger_tracer_started_spans", 2L);
+    expectedMetricCounts.put("jaeger_tracer_baggage_updates", 2L);
+    expectedMetricCounts.put("jaeger_tracer_sampler_queries", 2L);
+    expectedMetricCounts.put("jaeger_tracer_baggage_truncations", 1L);
+    expectedMetricCounts.put("jaeger_tracer_reporter_spans", 3L);
+    expectedMetricCounts.put("jaeger_tracer_traces", 4L);
+    expectedMetricCounts.put("jaeger_tracer_span_context_decoding_errors", 1L);
+    expectedMetricCounts.put("jaeger_tracer_reporter_queue_length", 1L);
   }
 
 
@@ -84,18 +84,18 @@ public class MicrometerTest {
   @Test
   public void testCounterWithoutExplicitTags() {
     metrics.decodingErrors.inc(1);
-    assertThat(registry.get("jaeger:span_context_decoding_errors").counter().count(), IsEqual.equalTo(1d));
-    assertTrue(prometheusRegistry.scrape().contains("jaeger:span_context_decoding_errors"));
+    assertThat(registry.get("jaeger_tracer_span_context_decoding_errors").counter().count(), IsEqual.equalTo(1d));
+    assertTrue(prometheusRegistry.scrape().contains("jaeger_tracer_span_context_decoding_errors"));
   }
 
   @Test
   public void testCounterWithExplicitTags() {
     metrics.tracesJoinedSampled.inc(1);
-    assertThat(registry.get("jaeger:traces").tags("sampled", "y", "state", "joined").counter().count(),
+    assertThat(registry.get("jaeger_tracer_traces").tags("sampled", "y", "state", "joined").counter().count(),
           IsEqual.equalTo(1d)
     );
     String output = prometheusRegistry.scrape();
-    assertTrue(output.contains("jaeger:traces"));
+    assertTrue(output.contains("jaeger_tracer_traces"));
     assertTrue(output.contains("sampled=\"y\""));
     assertTrue(output.contains("state=\"joined\""));
   }
@@ -103,8 +103,8 @@ public class MicrometerTest {
   @Test
   public void testGaugeWithoutExplicitTags() {
     metrics.reporterQueueLength.update(1);
-    assertThat(registry.get("jaeger:reporter_queue_length").gauge().value(), IsEqual.equalTo(1d));
-    assertTrue(prometheusRegistry.scrape().contains("jaeger:reporter_queue_length"));
+    assertThat(registry.get("jaeger_tracer_reporter_queue_length").gauge().value(), IsEqual.equalTo(1d));
+    assertTrue(prometheusRegistry.scrape().contains("jaeger_tracer_reporter_queue_length"));
   }
 
   @Test
@@ -112,11 +112,12 @@ public class MicrometerTest {
     // we have no timers on the Metrics class yet, so, we simulate one
     Map<String, String> tags = new HashMap<>(1);
     tags.put("akey", "avalue");
-    Timer timer = new MicrometerMetricsFactory().createTimer("jaeger:timed_operation", tags);
+    Timer timer = new MicrometerMetricsFactory().createTimer("jaeger_tracer_timed_operation", tags);
     timer.durationMicros(100);
 
-    assertThat(registry.get("jaeger:timed_operation").timer().totalTime(TimeUnit.MICROSECONDS), IsEqual.equalTo(100d));
-    assertTrue(prometheusRegistry.scrape().contains("jaeger:timed_operation_seconds"));
+    assertThat(registry.get("jaeger_tracer_timed_operation").timer().totalTime(TimeUnit.MICROSECONDS),
+        IsEqual.equalTo(100d));
+    assertTrue(prometheusRegistry.scrape().contains("jaeger_tracer_timed_operation_seconds"));
   }
 
 
@@ -164,16 +165,16 @@ public class MicrometerTest {
     createSomeSpans(tracer);
     tracer.close();
 
-    double finishedSpans = registry.get("jaeger:finished_spans")
+    double finishedSpans = registry.get("jaeger_tracer_finished_spans")
             .counter()
             .count();
 
-    double startedSpans = registry.get("jaeger:started_spans")
+    double startedSpans = registry.get("jaeger_tracer_started_spans")
             .tag("sampled", "y")
             .counter()
             .count();
 
-    double traces = registry.get("jaeger:traces")
+    double traces = registry.get("jaeger_tracer_traces")
             .tag("sampled", "y")
             .tag("state", "started")
             .counter()
@@ -204,7 +205,7 @@ public class MicrometerTest {
         .next();
 
     configuration.getTracer().buildSpan("theoperation").start().finish(100);
-    assertEquals(1, registry.find("jaeger:started_spans").counter().count(), 0);
+    assertEquals(1, registry.find("jaeger_tracer_started_spans").counter().count(), 0);
   }
 
   private void createSomeSpans(JaegerTracer tracer) {
@@ -212,7 +213,7 @@ public class MicrometerTest {
       JaegerSpan span = tracer.buildSpan("metricstest")
               .withTag("foo", "bar" + i)
               .start();
-      // Only finish every 3rd span so jaeger:started_spans and finished_spans counts are different
+      // Only finish every 3rd span so jaeger_tracer_started_spans and finished_spans counts are different
       if (i % 3 == 0) {
         span.finish();
       }


### PR DESCRIPTION
## Which problem is this PR solving?
Normalisation of the metric names used across the Jaeger tracers implemented in different languages as discussed in https://github.com/jaegertracing/jaeger/issues/572.

## Short description of the changes
As discussed [here](https://github.com/jaegertracing/jaeger/issues/572#issuecomment-426980837), this PR is updating the metric name prefix from `jaeger:` to `jaeger_tracer_` by default, while allowing developers to provide their own custom prefix.

The other part of the proposed change was to remove the `_total` suffix from the counters, to make it consistent with the metric names used in the Go client.

Unfortunately this suffix is being added by the [micrometer prometheus adapter](https://github.com/micrometer-metrics/micrometer/blob/dda79ab9091edde84bcbc90860020361c0a51578/implementations/micrometer-registry-prometheus/src/main/java/io/micrometer/prometheus/PrometheusNamingConvention.java#L64-L66), based on the [prometheus naming convention](https://prometheus.io/docs/practices/naming/#metric-names).

One option would be to leave the `_total` suffix in the Java tracer, and instead add the suffix to any other tracer that does not currently include it, as this would appear to follow the prometheus naming convention?


Signed-off-by: Gary Brown <gary@brownuk.com>