### PR TITLE
Expose senderFactory in SenderConfiguration (#569)

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
@@ -614,6 +614,11 @@ public class Configuration {
      */
     private String authPassword;
 
+    /**
+     * The SenderFactory type to use if multiple are found by {@link io.jaegertracing.internal.senders.SenderResolver}
+     */
+    private String senderFactory;
+
     public SenderConfiguration() {
     }
 
@@ -647,6 +652,11 @@ public class Configuration {
       return this;
     }
 
+    public SenderConfiguration withSenderFactory(String senderFactory) {
+      this.senderFactory = senderFactory;
+      return this;
+    }
+
     /**
      * Returns a sender if one was given when creating the configuration, or attempts to create a sender based on the
      * configuration's state.
@@ -672,13 +682,16 @@ public class Configuration {
       String authUsername = getProperty(JAEGER_USER);
       String authPassword = getProperty(JAEGER_PASSWORD);
 
+      String senderFactory = getProperty(JAEGER_SENDER_FACTORY);
+
       return new SenderConfiguration()
               .withAgentHost(agentHost)
               .withAgentPort(agentPort)
               .withEndpoint(collectorEndpoint)
               .withAuthToken(authToken)
               .withAuthUsername(authUsername)
-              .withAuthPassword(authPassword);
+              .withAuthPassword(authPassword)
+              .withSenderFactory(senderFactory);
     }
   }
 

--- a/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
@@ -74,6 +74,7 @@ public class ConfigurationTest {
     System.clearProperty(Configuration.JAEGER_PASSWORD);
     System.clearProperty(Configuration.JAEGER_PROPAGATION);
     System.clearProperty(Configuration.JAEGER_TRACEID_128BIT);
+    System.clearProperty(Configuration.JAEGER_SENDER_FACTORY);
 
     System.clearProperty(TEST_PROPERTY);
   }
@@ -208,6 +209,14 @@ public class ConfigurationTest {
   public void testSenderInstanceIsCached() {
     SenderConfiguration senderConfiguration = SenderConfiguration.fromEnv();
     assertEquals(senderConfiguration.getSender(), senderConfiguration.getSender());
+  }
+
+  @Test
+  public void testSenderFactoryIsReadFromProperty() {
+    String senderFactoryType = "sender-factory";
+    System.setProperty(Configuration.JAEGER_SENDER_FACTORY, senderFactoryType);
+    SenderConfiguration senderConfiguration = SenderConfiguration.fromEnv();
+    assertEquals(senderConfiguration.getSenderFactory(), senderFactoryType);
   }
 
   @Test


### PR DESCRIPTION
## Which problem is this PR solving?
This PR fixes #569

## Short description of the changes
This PR exposes senderFactory in SenderConfiguration. The SenderResolver uses this new configuration property or fallback to the system property for backward compatibility with existing code.