### PR TITLE
Always close HTTP responses in HttpSender

### DIFF
--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/HttpSender.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/HttpSender.java
@@ -69,18 +69,21 @@ public class HttpSender extends ThriftSender {
       throw new SenderException(String.format("Could not send %d spans", spans.size()), e, spans.size());
     }
 
-    if (!response.isSuccessful()) {
-      String responseBody;
-      try {
-        responseBody = response.body() != null ? response.body().string() : "null";
-      } catch (IOException e) {
-        responseBody = "unable to read response";
-      }
-
-      String exceptionMessage = String.format("Could not send %d spans, response %d: %s",
-          spans.size(), response.code(), responseBody);
-      throw new SenderException(exceptionMessage, null, spans.size());
+    if (response.isSuccessful()) {
+      response.close();
+      return;
     }
+
+    String responseBody;
+    try {
+      responseBody = response.body() != null ? response.body().string() : "null";
+    } catch (IOException e) {
+      responseBody = "unable to read response";
+    }
+
+    String exceptionMessage = String.format("Could not send %d spans, response %d: %s",
+        spans.size(), response.code(), responseBody);
+    throw new SenderException(exceptionMessage, null, spans.size());
   }
 
   public static class Builder {


### PR DESCRIPTION
The Response object wasn't closed when the response is successful,
leading to connection leaks. This was revealed by seeing messages like
this in logs:

```
WARNING: A connection to https://<redacted>/ was leaked. Did you forget to close a response body?
```

Signed-off-by: Maxime Petazzoni <max@signalfx.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- OkHttp3 reports connection leaks

## Short description of the changes
- This change makes sure that the Response object is always closed, even when the response is successful.
