### PR TITLE
Update reporter success metric on append in RemoteReporter (#211)

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/reporters/RemoteReporter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/reporters/RemoteReporter.java
@@ -137,7 +137,10 @@ public class RemoteReporter implements Reporter {
 
     @Override
     public void execute() throws SenderException {
-      sender.append(span);
+      int n = sender.append(span);
+      if (n > 0) {
+        metrics.reporterSuccess.inc(n);
+      }
     }
   }
 


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #211 

## Short description of the changes
Fix RemoteReporter to update the reporterSuccess metric when append operation triggered flush.

Signed-off-by: Igor Kurovsky <igor.kurovsky@gmail.com>