### PR TITLE
Use LinkedHashMap for span tags.

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
@@ -23,6 +23,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -62,7 +63,7 @@ public class JaegerSpan implements Span {
     this.startTimeMicroseconds = startTimeMicroseconds;
     this.startTimeNanoTicks = startTimeNanoTicks;
     this.computeDurationViaNanoTicks = computeDurationViaNanoTicks;
-    this.tags = new HashMap<String, Object>();
+    this.tags = new LinkedHashMap<String, Object>();
     this.references = references != null ? new ArrayList<Reference>(references) : null;
 
     for (Map.Entry<String, Object> tag : tags.entrySet()) {
@@ -93,7 +94,7 @@ public class JaegerSpan implements Span {
 
   public Map<String, Object> getTags() {
     synchronized (this) {
-      return Collections.unmodifiableMap(new HashMap<String, Object>(tags));
+      return Collections.unmodifiableMap(new LinkedHashMap<String, Object>(tags));
     }
   }
 

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
@@ -52,6 +52,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -227,7 +228,7 @@ public class JaegerTracer implements Tracer, Closeable {
      */
     private List<Reference> references = Collections.emptyList();
 
-    private final Map<String, Object> tags = new HashMap<String, Object>();
+    private final Map<String, Object> tags = new LinkedHashMap<String, Object>();
     private boolean ignoreActiveSpan = false;
 
     protected SpanBuilder(String operationName) {

--- a/jaeger-zipkin/src/test/java/io/jaegertracing/zipkin/internal/ThriftSpanConverterTest.java
+++ b/jaeger-zipkin/src/test/java/io/jaegertracing/zipkin/internal/ThriftSpanConverterTest.java
@@ -219,7 +219,7 @@ public class ThriftSpanConverterTest {
 
     com.twitter.zipkin.thriftjava.Span zipkinSpan = ThriftSpanConverter.convertSpan(span);
     String actualComponent =
-        new String(zipkinSpan.getBinary_annotations().get(3).getValue(), StandardCharsets.UTF_8);
+        new String(zipkinSpan.getBinary_annotations().get(2).getValue(), StandardCharsets.UTF_8);
     assertEquals(expectedComponentName, actualComponent);
   }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Issue #582 

## Short description of the changes
- Use `LinkedHashMap` to preserve the order of span tags.
