### PR TITLE
Updated thrift to 0.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ ext.developmentVersion = getProperty('developmentVersion','0.33.2-SNAPSHOT')
 
 ext.opentracingVersion = getProperty('opentracingVersion','0.31.0')
 ext.guavaVersion = getProperty('guavaVersion','18.0')
-ext.apacheThriftVersion = getProperty('apacheThriftVersion','0.11.0')
+ext.apacheThriftVersion = getProperty('apacheThriftVersion','0.12.0')
 ext.jerseyVersion = getProperty('jerseyVersion','2.22.2')
 ext.slf4jVersion = getProperty('slf4jVersion','1.7.25')
 ext.gsonVersion = getProperty('gsonVersion','2.8.2')

--- a/travis/docker-thrift/thrift
+++ b/travis/docker-thrift/thrift
@@ -2,7 +2,7 @@
 
 pwd=$(dirname ${PWD})
 
-THRIFT_VER=0.11.0
+THRIFT_VER=0.12.0
 THRIFT_IMG=thrift:${THRIFT_VER}
 THRIFT="docker run --rm -u $(id -u) -v ${pwd}:/data ${THRIFT_IMG} thrift"
 


### PR DESCRIPTION
Fixes #581 by bumping both the Java library and the Docker image for Thrift to 0.12.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
