### PR TITLE
Handle all exceptions during queue processing

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/reporters/RemoteReporter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/reporters/RemoteReporter.java
@@ -177,7 +177,7 @@ public class RemoteReporter implements Reporter {
           } catch (SenderException e) {
             metrics.reporterFailure.inc(e.getDroppedSpanCount());
           }
-        } catch (InterruptedException e) {
+        } catch (Exception e) {
           log.error("QueueProcessor error:", e);
           // Do nothing, and try again on next span.
         }


### PR DESCRIPTION
Fixes #590 

This reverts a change that made QueueProcessor only handle InterruptedException. Instead we want to ignore and log all exceptions because otherwise the QueueProcessor thread would fail silently.