### PR TITLE
Concurrency improvements to RemoteControlledSampler

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/RemoteControlledSampler.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/RemoteControlledSampler.java
@@ -70,8 +70,8 @@ public class RemoteControlledSampler implements Sampler {
           public void run() {
             try {
               updateSampler();
-            } catch (Exception e) {
-              // keep timer thread alive
+            } catch (Exception e) { // keep the timer thread alive
+              log.error("Failed to update sampler", e);
             }
           }
         },

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/utils/RateLimiter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/utils/RateLimiter.java
@@ -38,16 +38,13 @@ public class RateLimiter {
 
   public boolean checkCredit(double itemCost) {
     long cost = (long) (itemCost / creditsPerNanosecond);
-    long credit = clock.currentNanoTicks();
+    long credit;
     long currentDebit;
     long balance;
     do {
       currentDebit = debit.get();
+      credit = clock.currentNanoTicks();
       balance = credit - currentDebit;
-      if (balance < 0) { // in a very unlikely (but theoretically possible) race case
-        credit = System.nanoTime();
-        balance = credit - currentDebit;
-      }
       if (balance > maxBalance) {
         balance = maxBalance;
       }

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/samplers/RemoteControlledSamplerTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/samplers/RemoteControlledSamplerTest.java
@@ -170,4 +170,25 @@ public class RemoteControlledSamplerTest {
     assertEquals(new ProbabilisticSampler(0.001), undertest.getSampler());
   }
 
+  @Test
+  public void testConcurrentSampling() {
+    Sampler sampler = new Sampler() {
+
+      @Override
+      public SamplingStatus sample(String operation, long id) {
+        return null;
+      }
+
+      @Override
+      public void close() {
+
+      }
+    };
+    undertest = new RemoteControlledSampler.Builder(SERVICE_NAME)
+        .withSamplingManager(samplingManager)
+        .withInitialSampler(sampler)
+        .withMetrics(metrics)
+        .build();
+  }
+
 }

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/samplers/RemoteControlledSamplerTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/samplers/RemoteControlledSamplerTest.java
@@ -170,25 +170,4 @@ public class RemoteControlledSamplerTest {
     assertEquals(new ProbabilisticSampler(0.001), undertest.getSampler());
   }
 
-  @Test
-  public void testConcurrentSampling() {
-    Sampler sampler = new Sampler() {
-
-      @Override
-      public SamplingStatus sample(String operation, long id) {
-        return null;
-      }
-
-      @Override
-      public void close() {
-
-      }
-    };
-    undertest = new RemoteControlledSampler.Builder(SERVICE_NAME)
-        .withSamplingManager(samplingManager)
-        .withInitialSampler(sampler)
-        .withMetrics(metrics)
-        .build();
-  }
-
 }

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/utils/RateLimiterTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/utils/RateLimiterTest.java
@@ -14,15 +14,19 @@
 
 package io.jaegertracing.internal.utils;
 
-import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import io.jaegertracing.internal.clock.Clock;
+
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.Test;
 
 public class RateLimiterTest {
-  RateLimiter limiter;
 
   private static class MockClock implements Clock {
 
@@ -127,4 +131,59 @@ public class RateLimiterTest {
     assertTrue(limiter.checkCredit(1.0));
     assertFalse(limiter.checkCredit(1.0));
   }
+
+  /**
+   * Validates rate limiter behavior with {@link System#nanoTime()}-like (non-zero) initial nano ticks.
+   */
+  @Test
+  public void testRateLimiterInitial() {
+    MockClock clock = new MockClock();
+    clock.timeNanos = TimeUnit.MILLISECONDS.toNanos(-1_000_000);
+    RateLimiter limiter = new RateLimiter(1000, 100, clock);
+
+    assertTrue(limiter.checkCredit(100)); // consume initial (max) balance
+    assertFalse(limiter.checkCredit(1));
+
+    clock.timeNanos += TimeUnit.MILLISECONDS.toNanos(49); // add 49 credits
+    assertFalse(limiter.checkCredit(50));
+
+    clock.timeNanos += TimeUnit.MILLISECONDS.toNanos(1); // add one credit
+    assertTrue(limiter.checkCredit(50)); // consume accrued balance
+    assertFalse(limiter.checkCredit(1));
+
+    clock.timeNanos += TimeUnit.MILLISECONDS.toNanos(1_000_000); // add a lot of credits (max out balance)
+    assertTrue(limiter.checkCredit(1)); // take one credit
+
+    clock.timeNanos += TimeUnit.MILLISECONDS.toNanos(1_000_000); // add a lot of credits (max out balance)
+    assertFalse(limiter.checkCredit(101)); // can't consume more than max balance
+    assertTrue(limiter.checkCredit(100)); // consume max balance
+    assertFalse(limiter.checkCredit(1));
+  }
+
+  /**
+   * Validates concurrent credit check correctness.
+   */
+  @Test
+  public void testRateLimiterConcurrency() {
+    int numWorkers = ForkJoinPool.getCommonPoolParallelism();
+    int creditsPerWorker = 1000;
+    MockClock clock = new MockClock();
+    RateLimiter limiter = new RateLimiter(1, numWorkers * creditsPerWorker, clock);
+
+    AtomicInteger count = new AtomicInteger();
+    for (int w = 0; w < numWorkers; ++w) {
+      ForkJoinPool.commonPool().execute(() -> {
+        for (int i = 0; i < creditsPerWorker * 2; ++i) {
+          if (limiter.checkCredit(1)) {
+            count.getAndIncrement(); // count allowed operations
+          }
+        }
+      });
+    }
+    ForkJoinPool.commonPool().awaitQuiescence(1000, TimeUnit.MILLISECONDS);
+
+    assertEquals("Exactly the allocated number of credits must be consumed", numWorkers * creditsPerWorker,count.get());
+    assertFalse(limiter.checkCredit(1));
+  }
+
 }

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/utils/RateLimiterTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/utils/RateLimiterTest.java
@@ -180,7 +180,7 @@ public class RateLimiterTest {
         }
       });
     }
-    ForkJoinPool.commonPool().awaitQuiescence(1000, TimeUnit.MILLISECONDS);
+    ForkJoinPool.commonPool().awaitQuiescence(1, TimeUnit.SECONDS);
 
     assertEquals("Exactly the allocated number of credits must be consumed", numWorkers * creditsPerWorker,count.get());
     assertFalse(limiter.checkCredit(1));


### PR DESCRIPTION
This removes synchronization from RemoteControlledSampler and makes RateLimiter thread-safe.

## Which problem is this PR solving?
As described in #608 Synchronization in `RemoteControlledSampler` was causing severe performance degradation in multi-threaded applications.

`RateLimiter.checkBalance()` implementation was not thread-safe and didn't correctly initialize `lastTick`, causing non-deterministic behavior for the first invocation of `.checkBalance()`.

## Short description of the changes
Synchronization removed from `RemoteControlledSampler`.

Internal state of `RateLimiter` is now stored in `AtomicLong`s, with `.checkBalance()` modified to use an approach similar to `AtomicLong.getAndAccumulate()` - to prevent internal state corruption in concurrent flows.

Fixes #608