### PR TITLE
Use publish task in travis deploy goal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
 
     - stage: deploy
       env: [ NAME=deploy-to-maven ]
-      script: ./gradlew upload
+      script: ./gradlew publish
 
     - stage: deploy
       env: [ NAME=deploy-crossdock-to-dockerhub ]


### PR DESCRIPTION
The previous job failed https://travis-ci.org/jaegertracing/jaeger-client-java/builds/526035948 as I didn't update the task name in travis.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>

