### PR TITLE
Update java-tracerresolver to version 0.1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ ext.apacheThriftVersion = getProperty('apacheThriftVersion','0.12.0')
 ext.jerseyVersion = getProperty('jerseyVersion','2.22.2')
 ext.slf4jVersion = getProperty('slf4jVersion','1.7.25')
 ext.gsonVersion = getProperty('gsonVersion','2.8.2')
-ext.tracerResolverVersion = getProperty('tracerResolverVersion','0.1.5')
+ext.tracerResolverVersion = getProperty('tracerResolverVersion','0.1.6')
 ext.micrometerVersion = getProperty('micrometerVersion','1.0.0')
 ext.okhttpVersion = getProperty('okhttpVersion','3.9.0')
 


### PR DESCRIPTION
Version 0.1.5 of java-tracerresolver still dependes on OpenTracing 0.31.0.

Signed-off-by: Oliver Sand <oliver.sand@sda-se.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
-  java-tracerresolver 0.1.5 still depends on OpenTracing 0.31.0, but we would like to use 0.32.0, see my comment in #614

## Short description of the changes
- Change java-tracerresolver to version 0.1.6
