### PR TITLE
Fix nexus-publish config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id 'io.codearte.nexus-staging' version '0.20.0'
-    id "de.marcphilipp.nexus-publish" version "0.2.0"
+    id "de.marcphilipp.nexus-publish" version "0.2.0" apply false
     id 'com.github.ben-manes.versions' version '0.21.0'
 }
 
@@ -59,7 +59,7 @@ subprojects {
     apply plugin: 'maven'
     apply plugin: 'signing'
     apply plugin: 'checkstyle'
-    apply plugin: 'maven-publish'
+    apply plugin: 'de.marcphilipp.nexus-publish'
 
 
     compileJava {

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -19,17 +19,6 @@ task sourcesJar(type: Jar) {
 }
 
 publishing {
-    repositories {
-        maven {
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = getRepositoryUsername()
-                password = getRepositoryPassword()
-            }
-        }
-    }
     publications {
         mavenJava(MavenPublication) {
             groupId = 'io.jaegertracing'
@@ -74,8 +63,6 @@ publishing {
 
 
 nexusPublishing {
-    serverUrl = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-    snapshotRepositoryUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
     username = getRepositoryUsername()
     password = getRepositoryPassword()
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

Prior to this commit the configuration of the `nexus-publish` plugin was ineffective because it was only applied to the root project instead of all subprojects.

## Short description of the changes

Apply the nexus-publish plugin to all subprojects instead of the root
project, remove the explicitly configured repository and the default
server URLs.