### PR TITLE
Fixing RemoteBaggageRestrictionManager NullPointerException on empty response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ local.properties
 
 # IntelliJ
 /out/
+/jaeger-core/out/
 
 ### Intellij Patch ###
 # Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/baggage/RemoteBaggageRestrictionManager.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/baggage/RemoteBaggageRestrictionManager.java
@@ -79,6 +79,9 @@ public class RemoteBaggageRestrictionManager implements BaggageRestrictionManage
     List<BaggageRestrictionResponse> response;
     try {
       response = proxy.getBaggageRestrictions(serviceName);
+      if (response == null || response.isEmpty()) {
+        throw new BaggageRestrictionManagerException("empty restrictions response");
+      }
     } catch (BaggageRestrictionManagerException e) {
       metrics.baggageRestrictionsUpdateFailure.inc(1);
       return;


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- #630 
- Received the following exception when the `RemoteBaggageRestrictionManager` attempted to [update baggage restrictions](https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-core/src/main/java/io/jaegertracing/internal/baggage/RemoteBaggageRestrictionManager.java#L67):
```
Exception in thread "Timer-1" java.lang.NullPointerException
    at io.jaegertracing.internal.baggage.RemoteBaggageRestrictionManager.updateBaggageRestrictions(RemoteBaggageRestrictionManager.java:93)
    at io.jaegertracing.internal.baggage.RemoteBaggageRestrictionManager.updateBaggageRestrictions(RemoteBaggageRestrictionManager.java:87)
    at io.jaegertracing.internal.baggage.RemoteBaggageRestrictionManager$1.run(RemoteBaggageRestrictionManager.java:67)
    at java.util.TimerThread.mainLoop(Timer.java:555)
    at java.util.TimerThread.run(Timer.java:505)
```
- The `restrictions` [response may be `null`](https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-core/src/main/java/io/jaegertracing/internal/baggage/RemoteBaggageRestrictionManager.java#L81) because [`gson.fromJson()` returns `null`](https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-core/src/main/java/io/jaegertracing/internal/baggage/HttpBaggageRestrictionManagerProxy.java#L43) when `HttpBaggageRestrictionManagerProxy` receives an empty response from the remote server.


## Short description of the changes
- Throw `BaggageRestrictionManagerException` if the restrictions response is empty.
