### PR TITLE
Add public method isFinished() on JaegerSpan

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
@@ -75,6 +75,10 @@ public class JaegerSpan implements Span {
     return startTimeMicroseconds;
   }
 
+  public boolean isFinished() {
+    return finished;
+  }
+
   public long getDuration() {
     synchronized (this) {
       return durationMicroseconds;

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
@@ -76,7 +76,9 @@ public class JaegerSpan implements Span {
   }
 
   public boolean isFinished() {
-    return finished;
+    synchronized (this) {
+      return finished;
+    }
   }
 
   public long getDuration() {

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSpanTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSpanTest.java
@@ -159,6 +159,12 @@ public class JaegerSpanTest {
   }
 
   @Test
+  public void testFinished() {
+    jaegerSpan.finish();
+    assertTrue(jaegerSpan.isFinished());
+  }
+
+  @Test
   public void testSetTag() {
     jaegerSpan.setTag(new StringTag("stringTag"), "stringTagValue")
               .setTag(new IntTag("numberTag"), 1)


### PR DESCRIPTION
## Which problem is this PR solving?
In complicated future/multi-threading environments, such as RX java, you need to pass trace context to the executing threads.  In some cases we noticed that spans where been activated with the ScopeManager long after the span has finished (like 30 minutes). 
I've noticed hourly repeating tasks used stale trace context. By adding isFinished on the JaegerSpan, we can keep track (via metrics) of spans that are being activated but are themselves finished. 


## Short description of the changes
Adding public method isFinished to JaegerSpan.
