### PR TITLE
Add manifest entries to jaeger-thrift

### DIFF
--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -33,6 +33,12 @@ tasks.withType(Javadoc) {
    enabled = false
 }
 
+tasks.withType(Jar) {
+   manifest {
+      attributes('Implementation-Title': project.name, 'Implementation-Version': project.version, 'Specification-Version': project.version)
+   }
+}
+
 sourceSets {
     main {
         java {


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

## Which problem is this PR solving?
Manifest information is missing from the jaeger-thrift jars. This is because this module was excluded from the `configure` step in the top level `build.gradle` file that performs this task for all of the other jars.

## Short description of the changes
Add the task to the `build.gradle` file within the jaeger-thrift module.
