### PR TITLE
Add manifest entries to jaeger-thrift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 gen-java/
 jaeger-core/src/main/resources/io/jaegertracing/internal/jaeger.properties
 
+### VSCode ###
+.vscode/
+
 ### Eclipse ###
 
 .metadata

--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -30,7 +30,13 @@ compileThrift {
 }
 
 tasks.withType(Javadoc) {
-   enabled = false
+    enabled = false
+}
+
+tasks.withType(Jar) {
+    manifest {
+        attributes('Implementation-Title': project.name, 'Implementation-Version': project.version, 'Specification-Version': project.version)
+    }
 }
 
 sourceSets {


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

## Which problem is this PR solving?
Manifest entries are missing from the jaeger-thrift jars, as the task is being skipped for this module within the top level build.gradle.

## Short description of the changes
Add manifest entries to the jaeger-thrift module.
