### PR TITLE
Java: Cleanup operation samplers if absent from strategy response

### DIFF
--- a/jaeger-core/src/test/java/io/jaegertracing/internal/samplers/PerOperationSamplerTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/samplers/PerOperationSamplerTest.java
@@ -154,8 +154,8 @@ public class PerOperationSamplerTest {
     undertest.update(new OperationSamplingParameters(DEFAULT_SAMPLING_PROBABILITY,
                                                      DEFAULT_LOWER_BOUND_TRACES_PER_SECOND, parametersList));
 
-    assertEquals(1, operationToSamplers.size());
-    assertNotNull(operationToSamplers.get(OPERATION));
+    assertEquals(1, undertest.getOperationNameToSampler().size());
+    assertNotNull(undertest.getOperationNameToSampler().get(OPERATION));
   }
 
   @Test
@@ -169,10 +169,29 @@ public class PerOperationSamplerTest {
                                                      DEFAULT_LOWER_BOUND_TRACES_PER_SECOND,
                                                      parametersList));
 
-    assertEquals(1, operationToSamplers.size());
+    assertEquals(1, undertest.getOperationNameToSampler().size());
     assertEquals(new GuaranteedThroughputSampler(SAMPLING_RATE,
                                                  DEFAULT_LOWER_BOUND_TRACES_PER_SECOND),
-                 operationToSamplers.get(OPERATION));
+            undertest.getOperationNameToSampler().get(OPERATION));
   }
 
+  @Test
+  public void testAbsentOperationIsRemoved() {
+    String absentOp = "ShouldBeRemoved";
+    operationToSamplers.put(absentOp, mock(GuaranteedThroughputSampler.class));
+    PerOperationSamplingParameters perOperationSamplingParameters1 =
+            new PerOperationSamplingParameters(OPERATION, new ProbabilisticSamplingStrategy(SAMPLING_RATE));
+    List<PerOperationSamplingParameters> parametersList = new ArrayList<>();
+    parametersList.add(perOperationSamplingParameters1);
+
+    undertest.update(new OperationSamplingParameters(DEFAULT_SAMPLING_PROBABILITY,
+            DEFAULT_LOWER_BOUND_TRACES_PER_SECOND,
+            parametersList));
+
+    assertEquals(1, undertest.getOperationNameToSampler().size());
+    assertEquals(new GuaranteedThroughputSampler(SAMPLING_RATE,
+                    DEFAULT_LOWER_BOUND_TRACES_PER_SECOND),
+            undertest.getOperationNameToSampler().get(OPERATION));
+    assertFalse(undertest.getOperationNameToSampler().containsKey(absentOp));
+  }
 }


### PR DESCRIPTION
Signed-off-by: jung <jung@uber.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes [#1728](https://github.com/jaegertracing/jaeger/issues/1728)

## Short description of the changes
- If the server did not return a strategy for operation X, the operation sampler will be removed and the default sampler will be used for operation X
