### PR TITLE
Enhance logs for non-standard sender factory usage

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/senders/SenderResolver.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/senders/SenderResolver.java
@@ -56,6 +56,11 @@ public class SenderResolver {
     Iterator<SenderFactory> senderFactoryIterator = senderFactoryServiceLoader.iterator();
 
     boolean hasMultipleFactories = false;
+    String requestedFactory = System.getProperty(Configuration.JAEGER_SENDER_FACTORY);
+    boolean isRequestedFactoryAvailable = false;
+    if (!senderFactoryIterator.hasNext()) {
+      log.warn("No sender factories available");
+    }
     while (senderFactoryIterator.hasNext()) {
       SenderFactory senderFactory = senderFactoryIterator.next();
 
@@ -67,14 +72,13 @@ public class SenderResolver {
       if (hasMultipleFactories) {
         // we compare the factory name with JAEGER_SENDER_FACTORY, as a way to know which
         // factory the user wants:
-        String requestedFactory = System.getProperty(Configuration.JAEGER_SENDER_FACTORY);
         if (senderFactory.getType().equals(requestedFactory)) {
           log.debug(
               String.format("Found the requested (%s) sender factory: %s",
                   requestedFactory,
                   senderFactory)
           );
-
+          isRequestedFactoryAvailable = true;
           sender = getSenderFromFactory(senderFactory, senderConfiguration);
         }
       } else {
@@ -85,10 +89,16 @@ public class SenderResolver {
     if (null != sender) {
       log.debug(String.format("Using sender %s", sender));
       return sender;
+    } else if (requestedFactory == null && hasMultipleFactories) {
+      log.warn("Multiple factories available but JAEGER_SENDER_FACTORY property not specified.");
+    } else if (requestedFactory != null && hasMultipleFactories && !isRequestedFactoryAvailable) {
+      log.warn(
+          String.format("%s not available, using NoopSender, hence data will not be sent anywhere!",requestedFactory)
+      );
     } else {
       log.warn("No suitable sender found. Using NoopSender, meaning that data will not be sent anywhere!");
-      return new NoopSender();
     }
+    return new NoopSender();
   }
 
   private static Sender getSenderFromFactory(SenderFactory senderFactory,

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/senders/SenderResolver.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/senders/SenderResolver.java
@@ -55,12 +55,15 @@ public class SenderResolver {
         SenderFactory.class.getClassLoader());
     Iterator<SenderFactory> senderFactoryIterator = senderFactoryServiceLoader.iterator();
 
-    boolean hasMultipleFactories = false;
-    String requestedFactory = System.getProperty(Configuration.JAEGER_SENDER_FACTORY);
-    boolean isRequestedFactoryAvailable = false;
     if (!senderFactoryIterator.hasNext()) {
-      log.warn("No sender factories available");
+      log.warn("No sender factories available. Using NoopSender, meaning that data will not be sent anywhere!");
+      return new NoopSender();
     }
+
+    String requestedFactory = System.getProperty(Configuration.JAEGER_SENDER_FACTORY);
+    boolean hasMultipleFactories = false;
+    boolean isRequestedFactoryAvailable = false;
+
     while (senderFactoryIterator.hasNext()) {
       SenderFactory senderFactory = senderFactoryIterator.next();
 

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/senders/SenderResolverTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/senders/SenderResolverTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertTrue;
 import io.jaegertracing.Configuration;
 import io.jaegertracing.internal.JaegerSpan;
 import io.jaegertracing.spi.Sender;
-import io.jaegertracing.spi.SenderFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -30,7 +29,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Scanner;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class SenderResolverTest {

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/senders/SenderResolverTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/senders/SenderResolverTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Scanner;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class SenderResolverTest {
@@ -76,13 +77,6 @@ public class SenderResolverTest {
 
   @Test
   public void testMultipleImplementationsAmbiguous() throws Exception {
-    SenderFactoryToBeLoaded.sender = new CustomSender();
-    Sender sender = getSenderForServiceFileContents("\nio.jaegertracing.internal.senders.InMemorySenderFactory", true);
-    assertTrue(sender instanceof NoopSender);
-  }
-
-  @Test
-  public void testMultipleFactoriesButFactoryNotSpecified() throws Exception {
     SenderFactoryToBeLoaded.sender = new CustomSender();
     Sender sender = getSenderForServiceFileContents("\nio.jaegertracing.internal.senders.InMemorySenderFactory", true);
     assertTrue(sender instanceof NoopSender);

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/senders/SenderResolverTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/senders/SenderResolverTest.java
@@ -82,6 +82,22 @@ public class SenderResolverTest {
   }
 
   @Test
+  public void testMultipleFactoriesButFactoryNotSpecified() throws Exception {
+    SenderFactoryToBeLoaded.sender = new CustomSender();
+    Sender sender = getSenderForServiceFileContents("\nio.jaegertracing.internal.senders.InMemorySenderFactory", true);
+    assertTrue(sender instanceof NoopSender);
+  }
+
+  @Test
+  public void testSpecifiedFactoryNotInList() throws Exception {
+    System.setProperty(Configuration.JAEGER_SENDER_FACTORY, "SpecifiedFactory");
+    SenderFactoryToBeLoaded.sender = new CustomSender();
+    Sender sender = getSenderForServiceFileContents("\nio.jaegertracing.internal.senders.InMemorySenderFactory", true);
+    assertTrue(sender instanceof NoopSender);
+    System.clearProperty(Configuration.JAEGER_SENDER_FACTORY);
+  }
+
+  @Test
   public void testMultipleImplementationsNotAmbiguous() throws Exception {
     System.setProperty(Configuration.JAEGER_SENDER_FACTORY, "to-be-loaded");
     CustomSender customSender = new CustomSender();


### PR DESCRIPTION
Add logs to SenderResolver to handle non-standard usages
of SenderFactory. Commit addresses #532.

Signed-off-by: Bhargava Varadharajan <bhargavavaradh@gmail.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves #532 

## Short description of the changes
- Added logs to handle the three cases mentioned in #532 and added unit tests to test functionality.
