### PR TITLE
Add logging for SenderException in RemoteReporter

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/reporters/RemoteReporter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/reporters/RemoteReporter.java
@@ -104,6 +104,7 @@ public class RemoteReporter implements Reporter {
         metrics.reporterSuccess.inc(n);
       } catch (SenderException e) {
         metrics.reporterFailure.inc(e.getDroppedSpanCount());
+        log.error("Remote reporter error", e);
       }
       flushTimer.cancel();
     }


### PR DESCRIPTION
## Which problem is this PR solving?
Closes #653

## Short description of the changes
In order to get more context if a `SenderException` has been thrown, the complete exception is logged with `error` level.
