### PR TITLE
Create new trace if multiple non-childof refs from different traces

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
@@ -155,6 +155,11 @@ public class Configuration {
   public static final String JAEGER_TRACEID_128BIT = JAEGER_PREFIX + "TRACEID_128BIT";
 
   /**
+   *  Opt-in to use trace joins. By default, false.
+   */
+  public static final String JAEGER_TRACE_JOINS = JAEGER_PREFIX + "TRACE_JOINS";
+
+  /**
    * The supported trace context propagation formats.
    */
   public enum Propagation {
@@ -180,6 +185,7 @@ public class Configuration {
   private MetricsFactory metricsFactory;
   private Map<String, String> tracerTags;
   private boolean useTraceId128Bit;
+  private boolean allowTraceJoins;
 
   /**
    * lazy singleton JaegerTracer initialized in getTracer() method.
@@ -202,6 +208,7 @@ public class Configuration {
     return new Configuration(serviceName)
             .withTracerTags(tracerTagsFromEnv())
             .withTraceId128Bit(getPropertyAsBool(JAEGER_TRACEID_128BIT))
+            .withTraceJoins(getPropertyAsBool(JAEGER_TRACE_JOINS))
             .withReporter(ReporterConfiguration.fromEnv())
             .withSampler(SamplerConfiguration.fromEnv())
             .withCodec(CodecConfiguration.fromEnv());
@@ -230,6 +237,9 @@ public class Configuration {
         .withTags(tracerTags);
     if (useTraceId128Bit) {
       builder = builder.withTraceId128Bit();
+    }
+    if (allowTraceJoins) {
+      builder = builder.withTraceJoins();
     }
     codecConfig.apply(builder);
     return builder;
@@ -299,6 +309,11 @@ public class Configuration {
 
   public Configuration withTraceId128Bit(boolean useTraceId128Bit) {
     this.useTraceId128Bit = useTraceId128Bit;
+    return this;
+  }
+
+  public Configuration withTraceJoins(boolean allowTraceJoins) {
+    this.allowTraceJoins = allowTraceJoins;
     return this;
   }
 

--- a/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
@@ -76,6 +76,7 @@ public class ConfigurationTest {
     System.clearProperty(Configuration.JAEGER_PASSWORD);
     System.clearProperty(Configuration.JAEGER_PROPAGATION);
     System.clearProperty(Configuration.JAEGER_TRACEID_128BIT);
+    System.clearProperty(Configuration.JAEGER_TRACE_JOINS);
 
     System.clearProperty(TEST_PROPERTY);
   }
@@ -514,6 +515,20 @@ public class ConfigurationTest {
     assertEquals(1, codecConfiguration.getCodecs().get(Builtin.TEXT_MAP).size());
     assertTrue(codecConfiguration.getCodecs().get(Builtin.HTTP_HEADERS).get(0) instanceof B3TextMapCodec);
     assertTrue(codecConfiguration.getCodecs().get(Builtin.TEXT_MAP).get(0) instanceof B3TextMapCodec);
+  }
+
+  @Test
+  public void testAllowTraceJoinsDefault() {
+    System.setProperty(Configuration.JAEGER_SERVICE_NAME, "Test");
+    assertFalse(Configuration.fromEnv().getTracer().isAllowTraceJoins());
+  }
+
+  @Test
+  public void testAllowTraceJoinsTrue() {
+    System.setProperty(Configuration.JAEGER_SERVICE_NAME, "Test");
+    System.setProperty(Configuration.JAEGER_TRACE_JOINS, "true");
+
+    assertTrue(Configuration.fromEnv().getTracer().isAllowTraceJoins());
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
If a span is created with multiple "FOLLOWS_FROM" references from different traces, the new span is created as a child of the first supplied reference. As discussed on the bi-weekly call 18th Oct, this situation should result in a new trace being created.

## Short description of the changes
If more than one reference is supplied, with no CHILD_OF type, then check whether they belong to the same trace instance. If not, then treat as a root span of a new trace.
