### PR TITLE
Fix ThriftSender max span size check

### DIFF
--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/ThriftSender.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/ThriftSender.java
@@ -115,7 +115,7 @@ public abstract class ThriftSender extends ThriftSenderBase implements Sender {
       throw new SenderException("Failed to flush spans.", e, n);
     } finally {
       spanBuffer.clear();
-      spanBytesSize = processBytesSize;
+      spanBytesSize = 0;
     }
     return n;
   }

--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/ThriftSender.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/ThriftSender.java
@@ -29,7 +29,7 @@ public abstract class ThriftSender extends ThriftSenderBase implements Sender {
 
   private Process process;
   private int processBytesSize;
-  private int byteBufferSize;
+  private int spanBytesSize;
 
   @ToString.Exclude private List<io.jaegertracing.thriftjava.Span> spanBuffer;
 
@@ -49,7 +49,6 @@ public abstract class ThriftSender extends ThriftSenderBase implements Sender {
       process = new Process(span.getTracer().getServiceName());
       process.setTags(JaegerThriftSpanConverter.buildTags(span.getTracer().tags()));
       processBytesSize = calculateProcessSize(process);
-      byteBufferSize += processBytesSize;
     }
 
     io.jaegertracing.thriftjava.Span thriftSpan = JaegerThriftSpanConverter.convertSpan(span);
@@ -59,10 +58,10 @@ public abstract class ThriftSender extends ThriftSenderBase implements Sender {
           spanSize, getMaxSpanBytes()), null, 1);
     }
 
-    byteBufferSize += spanSize;
-    if (byteBufferSize <= getMaxBatchBytes()) {
+    spanBytesSize += spanSize;
+    if (spanBytesSize <= getMaxSpanBytes()) {
       spanBuffer.add(thriftSpan);
-      if (byteBufferSize < getMaxBatchBytes()) {
+      if (spanBytesSize < getMaxSpanBytes()) {
         return 0;
       }
       return flush();
@@ -77,7 +76,7 @@ public abstract class ThriftSender extends ThriftSenderBase implements Sender {
     }
 
     spanBuffer.add(thriftSpan);
-    byteBufferSize = processBytesSize + spanSize;
+    spanBytesSize = spanSize;
     return n;
   }
 
@@ -116,7 +115,7 @@ public abstract class ThriftSender extends ThriftSenderBase implements Sender {
       throw new SenderException("Failed to flush spans.", e, n);
     } finally {
       spanBuffer.clear();
-      byteBufferSize = processBytesSize;
+      spanBytesSize = processBytesSize;
     }
     return n;
   }

--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/ThriftSender.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/ThriftSender.java
@@ -54,9 +54,9 @@ public abstract class ThriftSender extends ThriftSenderBase implements Sender {
 
     io.jaegertracing.thriftjava.Span thriftSpan = JaegerThriftSpanConverter.convertSpan(span);
     int spanSize = calculateSpanSize(thriftSpan);
-    if (spanSize > getMaxSpanBytes()) {
+    if ((processBytesSize + spanSize) > getMaxSpanBytes()) {
       throw new SenderException(String.format("ThriftSender received a span that was too large, size = %d, max = %d",
-          spanSize, getMaxSpanBytes()), null, 1);
+          (processBytesSize + spanSize), getMaxSpanBytes()), null, 1);
     }
 
     byteBufferSize += spanSize;

--- a/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/ThriftSenderBase.java
+++ b/jaeger-thrift/src/main/java/io/jaegertracing/thrift/internal/senders/ThriftSenderBase.java
@@ -37,7 +37,7 @@ public abstract class ThriftSenderBase {
 
   protected final TProtocolFactory protocolFactory;
   private final TSerializer serializer;
-  private final int maxSpanBytes;
+  private final int maxBatchBytes;
 
   @ToString.Exclude private AutoExpandingBufferWriteTransport memoryTransport;
 
@@ -63,13 +63,13 @@ public abstract class ThriftSenderBase {
       maxPacketSize = ThriftUdpTransport.MAX_PACKET_SIZE;
     }
 
-    maxSpanBytes = maxPacketSize - EMIT_BATCH_OVERHEAD;
+    maxBatchBytes = maxPacketSize - EMIT_BATCH_OVERHEAD;
     memoryTransport = new AutoExpandingBufferWriteTransport(maxPacketSize, 2);
     serializer = new TSerializer(protocolFactory);
   }
 
-  protected int getMaxSpanBytes() {
-    return maxSpanBytes;
+  protected int getMaxBatchBytes() {
+    return maxBatchBytes;
   }
 
   protected byte[] serialize(TBase<?,?> thriftBase) throws Exception {

--- a/jaeger-thrift/src/test/java/io/jaegertracing/thrift/internal/senders/ThriftSenderTest.java
+++ b/jaeger-thrift/src/test/java/io/jaegertracing/thrift/internal/senders/ThriftSenderTest.java
@@ -50,6 +50,21 @@ public class ThriftSenderTest {
   }
 
   @Test(expected = SenderException.class)
+  public void appendFail() throws Exception {
+    int size = 0;
+    ThriftSender sender = new ThriftSender(ProtocolType.Compact, 0) {
+      @Override
+      public void send(Process process, List<Span> spans) throws SenderException {
+        throw new SenderException("", null, spans.size());
+      }
+    };
+
+    JaegerTracer tracer = new JaegerTracer.Builder("failure").build();
+    sender.append(tracer.buildSpan("flush-fail").start());
+    sender.flush();
+  }
+
+  @Test(expected = SenderException.class)
   public void flushFail() throws Exception {
     ThriftSender sender = new ThriftSender(ProtocolType.Compact, 0) {
       @Override

--- a/jaeger-thrift/src/test/java/io/jaegertracing/thrift/internal/senders/UdpSenderTest.java
+++ b/jaeger-thrift/src/test/java/io/jaegertracing/thrift/internal/senders/UdpSenderTest.java
@@ -149,9 +149,6 @@ public class UdpSenderTest {
 
     JaegerSpan jaegerSpan = buildSpanWithSize(maxPacketSize - UdpSender.EMIT_BATCH_OVERHEAD - processSize);
 
-    sender.append(jaegerSpan);
-
-    // add a span that overflows the limit to hit the last branch
     int result = sender.append(jaegerSpan);
 
     assertEquals(1, result);

--- a/jaeger-thrift/src/test/java/io/jaegertracing/thrift/internal/senders/UdpSenderTest.java
+++ b/jaeger-thrift/src/test/java/io/jaegertracing/thrift/internal/senders/UdpSenderTest.java
@@ -152,6 +152,11 @@ public class UdpSenderTest {
     int result = sender.append(jaegerSpan);
 
     assertEquals(1, result);
+
+    // test if the buffer is reinitialized correctly
+    result = sender.append(jaegerSpan);
+
+    assertEquals(1, result);
   }
 
   @Test(expected = SenderException.class)


### PR DESCRIPTION
Signed-off-by: Yeonghoon Park <me@yhpark.io>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Fixes #660. Currently the span size check only calculates the byte size of span, where it should also take the process size into account.

Consider a span with size less than `getMaxSpanBytes()` and greater than `getMaxSpanBytes() - processSize`. We cannot create a batch that fits UDP limit because we always have to send the `Process`. Still it passes the size check and corrupts write buffer in ThriftUdpTransport when flushed (which is another problem not dealt in this PR). Then the write buffer is always full with 65000 bytes in the buffer, never reinitialized, preventing all further spans from being sent.

I think this is a very critical issue because it causes the client to stop sending any spans altogether, and we actually encountered this problem frequently in production. For now, a workaround is to set the `ThriftSenderBase.maxPacketSize` value to something like 64000 by injecting a custom `ThriftSenderFactory` via ServiceLoader (see `SenderResolver.resolve()`). `Process` without custom tags takes around 100 bytes, so using value less than 64800 would be okay.

## Short description of the changes
- Before: `span size + Batch thrift overhead < 65000`
  (`spanSize > getMaxSpanBytes()`)
- After: `process size + span size + Batch thrift overhead < 65000`
  (`(processSize + spanSize) > getMaxSpanBytes()`)
