### PR TITLE
Fix release branch wildcard in gradle config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ def getProperty(name, defaultValue) {
 
 release {
     git {
-        requireBranch = 'master|release-*'
+        requireBranch = 'master|release-.*'
     }
     // default is x.x.x
     tagTemplate = "v" + project.properties["release.releaseVersion"]


### PR DESCRIPTION
I have discovered a bug when releasing from a release branch.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>

