### PR TITLE
Unregister shutdown hook when tracer is closed

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
@@ -79,6 +79,7 @@ public class JaegerTracer implements Tracer, Closeable {
   @ToString.Exclude private final BaggageSetter baggageSetter;
   @ToString.Exclude private final JaegerObjectFactory objectFactory;
   @ToString.Exclude private final int ipv4; // human readable representation is present within the tag map
+  @ToString.Exclude private Thread shutdownHook;
 
   protected JaegerTracer(JaegerTracer.Builder builder) {
     this.serviceName = builder.serviceName;
@@ -129,12 +130,13 @@ public class JaegerTracer implements Tracer, Closeable {
       log.info("No shutdown hook registered: Please call close() manually on application shutdown.");
     } else {
       // register this tracer with a shutdown hook, to flush the spans before the VM shuts down
-      Runtime.getRuntime().addShutdownHook(new Thread() {
+      shutdownHook = new Thread() {
         @Override
         public void run() {
           JaegerTracer.this.close();
         }
-      });
+      };
+      Runtime.getRuntime().addShutdownHook(shutdownHook);
     }
   }
 
@@ -224,6 +226,9 @@ public class JaegerTracer implements Tracer, Closeable {
   public void close() {
     reporter.close();
     sampler.close();
+    if (shutdownHook != null) {
+      Runtime.getRuntime().removeShutdownHook(shutdownHook);
+    }
   }
 
   public class SpanBuilder implements Tracer.SpanBuilder {


### PR DESCRIPTION
Resolves #677

Signed-off-by: Tomas Hofman <thofman@redhat.com>

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Avoid memory leak in JaegerTracer.

## Short description of the changes
- Unregister the shutdown hook when tracer is closed. (The hook is registered during tracer instance creation.)
