### PR TITLE
Feature request: sampling based on tags.

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/ProbabilisticTagSampler.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/ProbabilisticTagSampler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020, The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.jaegertracing.internal.samplers;
+
+import io.jaegertracing.spi.Sampler;
+import io.jaegertracing.spi.TagSampler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ProbabilisticTagSampler implements TagSampler {
+
+  private final String tagName;
+
+  private final HashMap<Object, Sampler> tagSamplers;
+
+  private final Sampler defaultSampler;
+
+  public ProbabilisticTagSampler(String tagName, Map<Object, Double> tagRates, double defaultRate) {
+    this.tagName = tagName;
+    this.defaultSampler = new ProbabilisticSampler(defaultRate);
+    this.tagSamplers = new HashMap<Object, Sampler>();
+    for (Map.Entry<Object, Double> rate : tagRates.entrySet()) {
+      tagSamplers.put(rate.getKey(), new ProbabilisticSampler(rate.getValue()));
+    }
+  }
+
+  @Override
+  public SamplingStatus sample(final String operation, final long id, final Map<String, Object> tags) {
+    final Object tagVal = tags.get(tagName);
+    Sampler tagSampler;
+    if (tagVal == null) {
+      tagSampler = defaultSampler;
+    } else {
+      tagSampler = tagSamplers.get(tagVal);
+      if (tagSampler == null) {
+        tagSampler = defaultSampler;
+      }
+    }
+    return tagSampler.sample(operation, id);
+  }
+
+  @Override
+  public SamplingStatus sample(final String operation, final long id) {
+    return defaultSampler.sample(operation, id);
+  }
+
+  @Override
+  public void close() {
+    defaultSampler.close();
+    for (Map.Entry<Object, Sampler> entry : tagSamplers.entrySet()) {
+      entry.getValue().close();
+    }
+  }
+}

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/TagSamplerWrapper.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/TagSamplerWrapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.jaegertracing.internal.samplers;
+
+import io.jaegertracing.spi.Sampler;
+import io.jaegertracing.spi.TagSampler;
+
+import java.util.Map;
+
+public class TagSamplerWrapper implements TagSampler {
+
+  private final Sampler baseSampler;
+
+  public TagSamplerWrapper(Sampler baseSampler) {
+    this.baseSampler = baseSampler;
+  }
+
+  public Sampler getBaseSampler() {
+    return this.baseSampler;
+  }
+
+  @Override
+  public SamplingStatus sample(final String operation, final long id) {
+    return baseSampler.sample(operation, id);
+  }
+
+  @Override
+  public SamplingStatus sample(final String operation, final long id, final Map<String, Object> tags) {
+    return baseSampler.sample(operation, id);
+  }
+
+  @Override
+  public void close() {
+    baseSampler.close();
+  }
+}

--- a/jaeger-core/src/main/java/io/jaegertracing/spi/TagSampler.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/spi/TagSampler.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2020, The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.jaegertracing.spi;
+
+import io.jaegertracing.internal.samplers.SamplingStatus;
+
+import java.util.Map;
+
+public interface TagSampler extends Sampler {
+  SamplingStatus sample(String operation, long id, Map<String, Object> tags);
+}


### PR DESCRIPTION
Sometimes it's important to be able to sample based on data rather than
opertaion names. Since tags are already available during the sampling
they can be used as an additional value to make a sampling decision.

For example in messages processing it would be helpful to trace some
topics more than other.

This is an example implementation of how could this work on the tracer
level.
The ProbabilisticTagSampler can be created to set different sampling rates for different tag values:
```
Map<Object, Double> rates = new HashMap<>();
rates.put("interesting_topic", 1.0);
rates.put("less_interesting_topic", 0.5);
Tracer tracer = Configuration.fromEnv().withSampler(new ProbabilisticTagSampler("topic", rates, 0.1).getTracer();
Span alwaysSampled = tracer.buildSpan("operation").withTag("topic", "interesting_topic").start();
Span oftenSampled = tracer.buildSpan("operation").withTag("topic", "less_interesting_topic").start();
Span rareSampled = tracer.buildSpan("operation").withTag("topic", "some_other_topic").start();

Tracer tracer = io.jaegertracing.Configuration.fromEnv().withSampler().getTracer();
final Span span = tracer.buildSpan("foo").withTag("interesting_topic").start();
```

Ideally it would be nice to have this feature on the agent/collector level as
well.

This is more of a feature request than a PR, the code is mostly to demonstrate possible API.