### PR TITLE
[Backport to 0.34] Configuration do not cache sender instance

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/Configuration.java
@@ -580,11 +580,6 @@ public class Configuration {
   @Getter
   public static class SenderConfiguration {
     /**
-     * A custom sender set by our consumers. If set, nothing else has effect. Optional.
-     */
-    private Sender sender;
-
-    /**
      * The Agent Host. Has no effect if the sender is set. Optional.
      */
     private String agentHost;
@@ -648,15 +643,11 @@ public class Configuration {
     }
 
     /**
-     * Returns a sender if one was given when creating the configuration, or attempts to create a sender based on the
-     * configuration's state.
+     * Returns a sender based on the configuration's state.
      * @return the sender passed via the constructor or a properly configured sender
      */
     public Sender getSender() {
-      if (sender == null) {
-        sender = SenderResolver.resolve(this);
-      }
-      return sender;
+      return SenderResolver.resolve(this);
     }
 
     /**

--- a/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
@@ -313,8 +313,11 @@ public class ConfigurationTest {
   @Test
   public void testDefaultTracer() {
     Configuration configuration = new Configuration("name");
-    assertNotNull(configuration.getTracer());
-    assertNotNull(configuration.getTracer());
+    JaegerTracer tracer = configuration.getTracer();
+    assertNotNull(tracer);
+    configuration.closeTracer();
+    tracer = configuration.getTracer();
+    assertNotNull(tracer);
     configuration.closeTracer();
   }
 


### PR DESCRIPTION
Backport #685

* Adding a closed attribute on sender
* Sender configuration is resolving again is sender is closed.

Issue: #684
Signed-off-by: Emmanuel Hugonnet <ehugonne@redhat.com>
