### PR TITLE
Revert "Unregister shutdown hook when tracer is closed (#678)"

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
@@ -77,7 +77,6 @@ public class JaegerTracer implements Tracer, Closeable {
   @ToString.Exclude private final BaggageSetter baggageSetter;
   @ToString.Exclude private final JaegerObjectFactory objectFactory;
   @ToString.Exclude private final int ipv4; // human readable representation is present within the tag map
-  @ToString.Exclude private Thread shutdownHook;
 
   protected JaegerTracer(JaegerTracer.Builder builder) {
     this.serviceName = builder.serviceName;
@@ -128,13 +127,12 @@ public class JaegerTracer implements Tracer, Closeable {
       log.info("No shutdown hook registered: Please call close() manually on application shutdown.");
     } else {
       // register this tracer with a shutdown hook, to flush the spans before the VM shuts down
-      shutdownHook = new Thread() {
+      Runtime.getRuntime().addShutdownHook(new Thread() {
         @Override
         public void run() {
           JaegerTracer.this.close();
         }
-      };
-      Runtime.getRuntime().addShutdownHook(shutdownHook);
+      });
     }
   }
 
@@ -225,9 +223,6 @@ public class JaegerTracer implements Tracer, Closeable {
   public void close() {
     reporter.close();
     sampler.close();
-    if (shutdownHook != null) {
-      Runtime.getRuntime().removeShutdownHook(shutdownHook);
-    }
   }
 
   public class SpanBuilder implements Tracer.SpanBuilder {


### PR DESCRIPTION
This reverts commit ed5a8c58b91ac62cfccc789dd096a87c4e81c0b8.

Signed-off-by: Tomas Hofman <thofman@redhat.com>

Upstream commit: https://github.com/jaegertracing/jaeger-client-java/pull/688

## Which problem is this PR solving?

This reverts fix for issue https://github.com/jaegertracing/jaeger-client-java/issues/677

The fix is causing issues when JaegerTracer#close is called when shutdown is already in progress - leading to IllegalStateException:

```
 java.lang.IllegalStateException: Shutdown in progress
	at java.lang.ApplicationShutdownHooks.remove(ApplicationShutdownHooks.java:82)
	at java.lang.Runtime.removeShutdownHook(Runtime.java:240)
	at io.jaegertracing.internal.JaegerTracer.close(JaegerTracer.java:229)
```

The memory leak itself, which the reverted commit intended to avoid, should not be a problem for regular applications as the JaegerTracer is designed to work as a singleton and the applications are not supposed to create more instances. Application servers can avoid it by other means.

## Short description of the changes

Just revert previous commit.
