### PR TITLE
Prevent a shutdown hook from being removed in JaegerTracer when a shutdown is in progress

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
@@ -131,6 +131,7 @@ public class JaegerTracer implements Tracer, Closeable {
       shutdownHook = new Thread() {
         @Override
         public void run() {
+          shutdownHook = null;
           JaegerTracer.this.close();
         }
       };


### PR DESCRIPTION
Prevent a shutdown hook from being removed in JaegerTracer when a shutdown is in progress

Signed-off-by: Tomas Hofman <thofman@redhat.com>

## Which problem is this PR solving?

This is follow up PR for https://github.com/jaegertracing/jaeger-client-java/pull/679

The problem this PR is solving that when a JaegerTracer is closed as a result of shutdown, the attempt to remove its' close shutdown hook fails with IllegalStateException. I.e. the shutdown hook cannot be removed when shutdown is already in progress.

## Short description of the changes

Do not remove a shutdown hook when a shutdown is already in progress.
