### PR TITLE
Avoid warning if traceparent not present

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/propagation/TraceContextCodec.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/propagation/TraceContextCodec.java
@@ -111,6 +111,9 @@ public class TraceContextCodec implements Codec<TextMap> {
         traceState = entry.getValue();
       }
     }
+    if (traceParent == null) {
+      return null;
+    }
     return extractContextFromTraceParent(traceParent, traceState);
   }
 


### PR DESCRIPTION
TextMapCodec.extract() return null with no warning if SPAN_CONTEXT_KEY not present, TraceContextCodec should align with it.
After switch `TextMapCodec` to `TraceContextCodec`, my application show lots of  [warning](https://github.com/jaegertracing/jaeger-client-java/blob/568ab68ec2ac5e9e811b1d0d76f752f3242d45d3/jaeger-core/src/main/java/io/jaegertracing/internal/propagation/TraceContextCodec.java#L73) .
I have to change my code to suppress it.
```
SpanContext parent = tracer.extract(Format.Builtin.HTTP_HEADERS, new HttpServletRequestTextMap(request));
```
add ugly null check
```
SpanContext parent = request.getHeader("traceparent") != null ? tracer.extract(Format.Builtin.HTTP_HEADERS, new HttpServletRequestTextMap(request)) : null;
```
