### PR TITLE
Mark TRACE_PARENT and TRACE_STATE as public

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/propagation/TraceContextCodec.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/propagation/TraceContextCodec.java
@@ -34,8 +34,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class TraceContextCodec implements Codec<TextMap> {
 
-  static final String TRACE_PARENT = "traceparent";
-  static final String TRACE_STATE = "tracestate";
+  public static final String TRACE_PARENT = "traceparent";
+  public static final String TRACE_STATE = "tracestate";
 
   private static final String VERSION = "00";
   private static final int VERSION_SIZE = 2;


### PR DESCRIPTION
Outside code can refer as constants
for example:
```
import java.util.Enumeration;
import java.util.HashMap;
import java.util.Iterator;
import java.util.Map;

import javax.servlet.http.HttpServletRequest;

import io.jaegertracing.internal.propagation.TraceContextCodec;
import io.opentracing.propagation.TextMap;
import io.opentracing.propagation.TextMapExtract;

public final class HttpServletRequestTextMap implements TextMapExtract {

	private final Map<String, String> map;

	public HttpServletRequestTextMap(HttpServletRequest request) {
		map = new HashMap<>();
		Enumeration<String> en = request.getHeaderNames();
		while (en.hasMoreElements()) {
			String name = en.nextElement();
			if (name.equals(TraceContextCodec.TRACE_PARENT) || name.equals(TraceContextCodec.TRACE_STATE))
				map.put(name, request.getHeader(name));
		}
	}

	@Override
	public Iterator<Map.Entry<String, String>> iterator() {
		return map.entrySet().iterator();
	}

}
```