### PR TITLE
Fix publishing jaeger-thrift shadow artifact

### DIFF
--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -80,3 +80,17 @@ artifacts {
     }
     tests testJar
 }
+
+publishing {
+    publications {
+        shadow(MavenPublication) { publication ->
+            project.shadow.component(publication)
+        }
+    }
+}
+
+signing {
+    if (isReleaseVersion) {
+        sign publishing.publications.shadow
+    }
+}


### PR DESCRIPTION
## Which problem is this PR solving?
- Missing shadow artifact (#645) 

## Short description of the changes
- add publication and signing configuration for jaeger-thrift shadow artifact (this is currently not published as the current configuration only publishes `components.java` + sources + javadocs)

## Testing performed
- `./gradlew publishToMavenLocal -PskipSigning=true` and verified that the shadow artifact is deployed to local maven repository
- `./gradlew publishToMavenLocal` and observed that `:jaeger-thrift:signShadowPublication` fails (it's not a full test, but should be good enough)
