### PR TITLE
Support sampling decision in B3-protocol

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
@@ -223,9 +223,12 @@ public class JaegerSpan implements Span {
       int priority = ((Number) value).intValue();
       byte newFlags;
       if (priority > 0) {
-        newFlags = (byte) (context.getFlags() | JaegerSpanContext.flagSampled | JaegerSpanContext.flagDebug);
+        newFlags = (byte) (context.getFlags()
+                | JaegerSpanContext.flagSampled | JaegerSpanContext.flagSampledSet | JaegerSpanContext.flagDebug);
       } else {
-        newFlags = (byte) (context.getFlags() & (~JaegerSpanContext.flagSampled));
+        // https://github.com/opentracing/specification/blob/master/semantic_conventions.md
+        // If 0, a hint to the trace to not-capture the trace.
+        newFlags = (byte) ((context.getFlags() & (~JaegerSpanContext.flagSampled)) | JaegerSpanContext.flagSampledSet);
       }
 
       context = context.withFlags(newFlags);

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpanContext.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpanContext.java
@@ -24,7 +24,8 @@ import java.util.Map;
 
 public class JaegerSpanContext implements SpanContext {
   protected static final byte flagSampled = 1;
-  protected static final byte flagDebug = 2;
+  protected static final byte flagDebug = 1 << 1;
+  protected static final byte flagSampledSet = 1 << 2;
 
   private final long traceIdLow;
   private final long traceIdHigh;
@@ -130,8 +131,8 @@ public class JaegerSpanContext implements SpanContext {
     return traceState;
   }
 
-  public boolean isSampled() {
-    return (flags & flagSampled) == flagSampled;
+  public Boolean isSampled() {
+    return (flags & flagSampledSet) == flagSampledSet ? (flags & flagSampled) == flagSampled : null;
   }
 
   public boolean isDebug() {

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerTracer.java
@@ -422,14 +422,20 @@ public class JaegerTracer implements Tracer, Closeable {
         } else {
           long traceIdHigh = isUseTraceId128Bit() ? Utils.uniqueId() : 0;
           long traceIdLow = spanId;
+          String debugId = getDebugId();
+          byte flags = preferredReference.getFlags();
+          if (debugId != null) {
+            flags = (byte) (flags | JaegerSpanContext.flagSampled | JaegerSpanContext.flagDebug);
+            tags.put(Constants.DEBUG_ID_HEADER_KEY, debugId);
+          }
           return getObjectFactory().createSpanContext(
                   traceIdHigh,
                   traceIdLow,
                   spanId,
                   0,
-                  preferredReference.getFlags(),
+                  flags,
                   getBaggage(),
-                  null);
+                  debugId);
         }
       }
     }

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/propagation/B3TextMapCodec.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/propagation/B3TextMapCodec.java
@@ -55,8 +55,10 @@ public class B3TextMapCodec implements Codec<TextMap> {
   protected static final String FLAGS_NAME = "X-B3-Flags";
   protected static final String BAGGAGE_PREFIX = "baggage-";
   // NOTE: uber's flags aren't the same as B3/Finagle ones
-  protected static final byte SAMPLED_FLAG = 1;
-  protected static final byte DEBUG_FLAG = 2;
+  protected static final byte SAMPLED_SET_FLAG = 1 << 2;
+  protected static final byte NOT_SAMPLED_FLAG = SAMPLED_SET_FLAG;
+  protected static final byte SAMPLED_FLAG = 1 | SAMPLED_SET_FLAG;
+  protected static final byte DEBUG_FLAG = 1 << 1;
 
   private static final PrefixedKeys keys = new PrefixedKeys();
   private final String baggagePrefix;
@@ -109,6 +111,7 @@ public class B3TextMapCodec implements Codec<TextMap> {
           flags |= SAMPLED_FLAG;
           sampleDecision = true;
         } else if ("0".equals(value) || "false".equalsIgnoreCase(value)) {
+          flags |= NOT_SAMPLED_FLAG;
           sampleDecision = false;
         }
       } else if (entry.getKey().equalsIgnoreCase(TRACE_ID_NAME)) {

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/propagation/TraceContextCodec.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/propagation/TraceContextCodec.java
@@ -50,6 +50,7 @@ public class TraceContextCodec implements Codec<TextMap> {
   private static final int TRACE_OPTION_OFFSET =
       SPAN_ID_OFFSET + SPAN_ID_HEX_SIZE + TRACEPARENT_DELIMITER_SIZE;
   private static final int TRACEPARENT_HEADER_SIZE = TRACE_OPTION_OFFSET + TRACE_FLAGS_HEX_SIZE;
+  // sampled flag plus sampled set
   private static final byte SAMPLED_FLAG = 1;
 
   private final JaegerObjectFactory objectFactory;
@@ -94,7 +95,7 @@ public class TraceContextCodec implements Codec<TextMap> {
         traceIdLow,
         spanId,
         0,
-        sampled ? (byte) 1 : (byte) 0,
+        sampled ? (byte) (1 | (1 << 2)) : (byte) (1 << 2),
         Collections.<String, String>emptyMap(), null);
     return spanContext.withTraceState(tracestate);
   }

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerTracerTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerTracerTest.java
@@ -224,7 +224,7 @@ public class JaegerTracerTest {
   public void testOnlySamplingDecisionWithParent() {
     JaegerSpan parentSpan = tracer.buildSpan("parent").start();
     parentSpan.setBaggageItem("parentFoo", "parentBar");
-    Scope scope = tracer.activateSpan(parentSpan);
+    final Scope scope = tracer.activateSpan(parentSpan);
 
     String expectedOperation = "onlyTrueSamplingDecision";
     JaegerSpanContext spanContext = new JaegerSpanContext(0L, 0L, 0L, 0L, (byte) 1);

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerTracerTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerTracerTest.java
@@ -206,6 +206,21 @@ public class JaegerTracerTest {
   }
 
   @Test
+  public void testFalseSamplingDecision() {
+    String expectedOperation = "falseSamplingDecision";
+    JaegerSpanContext spanContext = new JaegerSpanContext(0L, 0L, 0L, 0L, (byte) 0);
+
+    assertFalse(spanContext.hasTrace());
+
+    JaegerSpan span = tracer.buildSpan(expectedOperation).asChildOf(spanContext).start();
+
+    assertEquals(expectedOperation, span.getOperationName());
+    assertFalse(span.context().isSampled());
+    assertTrue(span.context().hasTrace());
+    span.finish();
+  }
+
+  @Test
   public void testOnlySamplingDecisionWithParent() {
     JaegerSpan parentSpan = tracer.buildSpan("parent").start();
     parentSpan.setBaggageItem("parentFoo", "parentBar");

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/propagation/B3TextMapCodecTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/propagation/B3TextMapCodecTest.java
@@ -14,10 +14,6 @@
 
 package io.jaegertracing.internal.propagation;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import io.jaegertracing.internal.JaegerSpanContext;
 import io.opentracing.propagation.TextMap;
 import java.util.Iterator;
@@ -26,6 +22,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * NOTE:
@@ -102,6 +100,18 @@ public class B3TextMapCodecTest {
     b3Codec.inject(spanContext, entries);
     assertEquals(5, entries.delegate.size());
     assertEquals("bar", entries.delegate.get("foofoo"));
+  }
+
+  @Test
+  public void testDenySamplingDecisionWithBaggage() {
+    DelegatingTextMap entries = new DelegatingTextMap();
+    entries.put(B3TextMapCodec.SAMPLED_NAME, "1");
+    entries.put(B3TextMapCodec.BAGGAGE_PREFIX + "foo", "bar");
+
+    JaegerSpanContext spanContext = b3Codec.extract(entries);
+    assertNotNull(spanContext);
+    assertTrue(spanContext.isSampled());
+    assertEquals("bar", spanContext.getBaggageItem("foo"));
   }
 
   @Test

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/propagation/B3TextMapCodecTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/propagation/B3TextMapCodecTest.java
@@ -35,7 +35,8 @@ import org.junit.Test;
  *
  */
 public class B3TextMapCodecTest {
-  static final byte SAMPLED = 1;
+  static final byte SAMPLED = B3TextMapCodec.SAMPLED_FLAG;
+  static final byte NOT_SAMPLED = B3TextMapCodec.NOT_SAMPLED_FLAG;
 
   B3TextMapCodec b3Codec = new B3TextMapCodec.Builder().build();
 
@@ -74,7 +75,7 @@ public class B3TextMapCodecTest {
     long traceIdLow = 1;
     long spanId = 2;
     long parentId = 3;
-    JaegerSpanContext spanContext = new JaegerSpanContext(0L, traceIdLow, spanId, parentId, (byte)0)
+    JaegerSpanContext spanContext = new JaegerSpanContext(0L, traceIdLow, spanId, parentId, NOT_SAMPLED)
         .withBaggageItem("foo", "bar");
 
     b3Codec.inject(spanContext, entries);
@@ -96,7 +97,7 @@ public class B3TextMapCodecTest {
     long traceIdLow = 1;
     long spanId = 2;
     long parentId = 3;
-    JaegerSpanContext spanContext = new JaegerSpanContext(0L, traceIdLow, spanId, parentId, (byte)0)
+    JaegerSpanContext spanContext = new JaegerSpanContext(0L, traceIdLow, spanId, parentId, NOT_SAMPLED)
         .withBaggageItem("foo", "bar");
 
     b3Codec.inject(spanContext, entries);

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/propagation/B3TextMapCodecTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/propagation/B3TextMapCodecTest.java
@@ -14,6 +14,10 @@
 
 package io.jaegertracing.internal.propagation;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import io.jaegertracing.internal.JaegerSpanContext;
 import io.opentracing.propagation.TextMap;
 import java.util.Iterator;
@@ -22,8 +26,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 /**
  * NOTE:

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/propagation/TraceContextCodecTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/propagation/TraceContextCodecTest.java
@@ -41,7 +41,7 @@ import org.mockito.Mockito;
 public class TraceContextCodecTest {
 
   private static final JaegerSpanContext SPAN_CONTEXT =
-      new JaegerSpanContext(0, 1, 2, 3, (byte)0);
+      new JaegerSpanContext(0, 1, 2, 3, (byte) (1 << 2));
   private static final String EXAMPLE_TRACE_PARENT = "00-00000000000000000000000000000001-0000000000000002-00";
   private static PrintStream sysout;
 
@@ -83,7 +83,7 @@ public class TraceContextCodecTest {
     long spanId = 2;
     long parentId = 3;
     long traceIdHigh = HexCodec.hexToUnsignedLong("c281c27976c85681", 0, 16);
-    JaegerSpanContext spanContext = new JaegerSpanContext(traceIdHigh, traceIdLow, spanId, parentId, (byte) 0);
+    JaegerSpanContext spanContext = new JaegerSpanContext(traceIdHigh, traceIdLow, spanId, parentId, (byte) (1 << 2));
 
     traceContextCodec.inject(spanContext, textMap);
 
@@ -104,7 +104,7 @@ public class TraceContextCodecTest {
     String traceParent = carrier.get(TRACE_PARENT);
     assertEquals(EXAMPLE_TRACE_PARENT, traceParent);
     JaegerSpanContext extractedContext = traceContextCodec.extract(textMap);
-    assertEquals("1:2:0:0", extractedContext.toString());
+    assertEquals("1:2:0:4", extractedContext.toString());
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: megrez <lujiajing1126@gmail.com>

Focus on #708 

Also related to #624 

## Which problem is this PR solving?

According to the [B3 propagation protocol](https://github.com/openzipkin/b3-propagation),
client can send header "X-B3-Sampled: 0" without any TraceId and ParentId fields.

The sampling decision will be respected if no other trace exists.

## Short description of the changes

- Change `B3TextMapCodec` to support passing `X-B3-Sampled` only.
- Change `JaegerTracer` to support this feature.
- Necessary test cases are added to cover all code paths.
- In `jaeger` tracer, there is no `SamplingSet` mark in the flag, so it is impossible to determine the sampling status. In this PR, I also add a flag `1 << 2` to mark whether the sampling decision has been made.
