### PR TITLE
Ignore case while extract W3C TraceContext

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/propagation/TraceContextCodec.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/propagation/TraceContextCodec.java
@@ -106,13 +106,13 @@ public class TraceContextCodec implements Codec<TextMap> {
     String traceState = null;
     String debugId = null;
     for (Map.Entry<String, String> entry: carrier) {
-      if (TRACE_PARENT.equals(entry.getKey())) {
+      if (TRACE_PARENT.equalsIgnoreCase(entry.getKey())) {
         traceParent = entry.getValue();
       }
-      if (TRACE_STATE.equals(entry.getKey())) {
+      if (TRACE_STATE.equalsIgnoreCase(entry.getKey())) {
         traceState = entry.getValue();
       }
-      if (Constants.DEBUG_ID_HEADER_KEY.equals(entry.getKey())) {
+      if (Constants.DEBUG_ID_HEADER_KEY.equalsIgnoreCase(entry.getKey())) {
         debugId = entry.getValue();
       }
     }

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/propagation/TraceContextCodecTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/propagation/TraceContextCodecTest.java
@@ -117,6 +117,17 @@ public class TraceContextCodecTest {
   }
 
   @Test
+  public void testExtractWithCapitalizedTraceHeaders() {
+    Map<String, String> extractCarrier = new HashMap<>();
+    TextMapAdapter textMap = new TextMapAdapter(extractCarrier);
+    textMap.put("Traceparent", EXAMPLE_TRACE_PARENT);
+    textMap.put("Tracestate", "whatever");
+    JaegerSpanContext spanContext = traceContextCodec.extract(textMap);
+    assertEquals("1:2:0:0", spanContext.toString());
+    assertEquals("whatever", spanContext.getTraceState());
+  }
+
+  @Test
   public void testInvalidTraceId() {
     TextMapAdapter textMap = new TextMapAdapter(new HashMap<>());
     textMap.put(TRACE_PARENT, "00-00000000000000000000000000000000-0000000000000002-00");


### PR DESCRIPTION
1. align with other codec
2. jetty will capitalize header name
