### PR TITLE
Do not encode span context in HTTP_HEADERS format

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/propagation/TextMapCodec.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/propagation/TextMapCodec.java
@@ -126,7 +126,7 @@ public class TextMapCodec implements Codec<TextMap> {
 
   @Override
   public void inject(JaegerSpanContext spanContext, TextMap carrier) {
-    carrier.put(contextKey, encodedValue(contextAsString(spanContext)));
+    carrier.put(contextKey, contextAsString(spanContext));
     for (Map.Entry<String, String> entry : spanContext.baggageItems()) {
       carrier.put(keys.prefixedKey(entry.getKey(), baggagePrefix), encodedValue(entry.getValue()));
     }


### PR DESCRIPTION
## Which problem is this PR solving?

String representation of a span context is safe to use in HTTP header. Thus, there is no need to encode it. JS & Go clients
already avoid that unnecessary encoding. 

Resolves #720 

## Short description of the changes

This change is backward compatible because all clients unencode span context even if they do not encode it. More pragmatically, a client impacted by this change would already be incompatible with JS & Go clients.