### PR TITLE
Fix publishing to Nexus

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -19,6 +19,9 @@ publishing {
             from components.java
             artifact sourcesJar
             artifact javadocJar
+            project.plugins.withId('com.github.johnrengelman.shadow') {
+                artifact project.tasks.shadowJar
+            }
 
             pom {
                 name = 'jaeger-client'

--- a/jaeger-thrift/build.gradle
+++ b/jaeger-thrift/build.gradle
@@ -80,17 +80,3 @@ artifacts {
     }
     tests testJar
 }
-
-publishing {
-    publications {
-        shadow(MavenPublication) { publication ->
-            project.shadow.component(publication)
-        }
-    }
-}
-
-signing {
-    if (isReleaseVersion) {
-        sign publishing.publications.shadow
-    }
-}


### PR DESCRIPTION
## Which problem is this PR solving?
- Publishing to Nexus is failing (#722)

## Short description of the changes
- consolidate publishing shadow artifact and the rest into a single task (shadow publishing task was trying to publish its own POM and that POM was messing up with the main POM)

## Testing performed
- Run `./gradlew jaeger-thrift:publishToMavenLocal` on master with #704 reverted and this branch and observed that:
  - `jaeger-thrift-1.3.1-SNAPSHOT-shadow.jar` is present only when publishing from this branch
  - `jaeger-thrift-1.3.1-SNAPSHOT.pom` looks the same when publishing form both branches and is sane in general
- Since this change is affecting all the things that use `com.github.johnrengelman.shadow`, I also verified that what is published by `jaeger-crossdock` looks reasonably sane, so I hope this won't break
- Run `publishToMavenLocal` on all subprojects and verified that there are no errors

