### PR TITLE
Make UdpSender lazy to be able to recover from early DNS issues

### DIFF
--- a/jaeger-thrift/src/test/java/io/jaegertracing/thrift/internal/senders/ThriftSenderFactoryTest.java
+++ b/jaeger-thrift/src/test/java/io/jaegertracing/thrift/internal/senders/ThriftSenderFactoryTest.java
@@ -17,7 +17,6 @@ package io.jaegertracing.thrift.internal.senders;
 import static org.junit.Assert.assertTrue;
 
 import io.jaegertracing.Configuration;
-import io.jaegertracing.internal.senders.NoopSender;
 import io.jaegertracing.spi.Sender;
 import org.junit.Before;
 import org.junit.Test;
@@ -47,7 +46,7 @@ public class ThriftSenderFactoryTest {
     System.setProperty(Configuration.JAEGER_AGENT_HOST, "jaeger-agent");
     System.setProperty(Configuration.JAEGER_AGENT_PORT, "6832");
     Sender sender = Configuration.SenderConfiguration.fromEnv().getSender();
-    assertTrue(sender instanceof NoopSender);
+    assertTrue(sender instanceof UdpSender);
   }
 
   @Test

--- a/jaeger-thrift/src/test/java/io/jaegertracing/thrift/internal/senders/UdpLazinessTest.java
+++ b/jaeger-thrift/src/test/java/io/jaegertracing/thrift/internal/senders/UdpLazinessTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020, The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.jaegertracing.thrift.internal.senders;
+
+import io.jaegertracing.internal.exceptions.SenderException;
+import org.junit.Test;
+
+import java.net.SocketException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class UdpLazinessTest {
+    @Test
+    public void testLazyInitializationOfAgent() {
+        UdpSender udpSender = new UdpSender("agent.acme.test", 55555, 0);
+
+        try {
+            udpSender.send(null, Collections.emptyList());
+            fail("Send should fail!");
+        } catch (SenderException e) {
+            assertTrue("send should throw a socket exception", e.getCause().getCause() instanceof SocketException);
+        }
+    }
+}


### PR DESCRIPTION
this should close #369

<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Issue #369 

## Short description of the changes
- made the UdpSender lazily create the ThriftUdpTransport instance to prevent early DNS errors from causing initialization errors. This does require locking, which has been implemented using the double-checked locking pattern to reduce the lock overhead for (usually) the majority of send calls.
