### PR TITLE
avoid holding too many span instances in memory

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/reporters/LoggingReporter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/reporters/LoggingReporter.java
@@ -40,7 +40,7 @@ public class LoggingReporter implements Reporter {
 
   @Override
   public void report(JaegerSpan span) {
-    logger.info("Span reported: {}", span);
+    logger.info("Span reported: {}", span.toString());
   }
 
   @Override


### PR DESCRIPTION
## Which problem is this PR solving?
-

I found a leaking memory issue when I do stress testing within LoggingReporter. In case, many Span instances are held on memory. 

In fact, I am not very sure about the key causes yet.  But this change seems available in my case. 

## Short description of the changes
-
