### PR TITLE
Allow SystemClock to recognize non-GA OpenJDK versions

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/clock/SystemClock.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/clock/SystemClock.java
@@ -31,7 +31,9 @@ public class SystemClock implements Clock {
 
   private static int getJavaVersion() {
     val sections = System.getProperty("java.version").split("\\.");
-    val major = Integer.parseInt(sections[0]);
+    // Checking if major is in fact GA release or not (see please https://openjdk.java.net/jeps/223)
+    val index = sections[0].indexOf("-");
+    val major = Integer.parseInt((index == -1) ? sections[0] : sections[0].substring(0, index));
     return major == 1 ? Integer.parseInt(sections[1]) : major;
   }
 

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/clock/SystemClock.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/clock/SystemClock.java
@@ -30,7 +30,11 @@ public class SystemClock implements Clock {
   private static final Clock DELEGATE;
 
   private static int getJavaVersion() {
-    val sections = System.getProperty("java.version").split("\\.");
+    return parseJavaVersion(System.getProperty("java.version"));
+  }
+  
+  static int parseJavaVersion(String property) {
+    val sections = property.split("\\.");
     // Checking if major is in fact GA release or not (see please https://openjdk.java.net/jeps/223)
     val index = sections[0].indexOf("-");
     val major = Integer.parseInt((index == -1) ? sections[0] : sections[0].substring(0, index));

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/clock/SystemClockTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/clock/SystemClockTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018, The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.jaegertracing.internal.clock;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class SystemClockTest {
+  @Parameters(name = "java.version {0}: major is {1}")
+  public static Collection<Object[]> version() {
+    return Arrays.asList(new Object[][] {     
+        { "9", 9 }, 
+        { "16-ea", 16 }, 
+        { "11.0.5", 11 }, 
+        { "1.8.0_231", 8 }
+    });
+  }
+    
+  private String property;
+  private int version;
+
+  public SystemClockTest(String property, int version) {
+    this.property = property;
+    this.version = version;
+  }
+  
+  @Test
+  public void test() {
+    assertThat(SystemClock.parseJavaVersion(property), equalTo(version));
+  }
+}

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/clock/SystemClockTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/clock/SystemClockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, The Jaeger Authors
+ * Copyright (c) 2020, The Jaeger Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
## Which problem is this PR solving?

While testing Apache CXF with OpenJDK 16 Early Builds, we run into the issues with Java version parsing which `SystemClock` does under the hood:

```
Caused by: java.lang.NumberFormatException: For input string: "16-ea"
        at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:68)
        at java.base/java.lang.Integer.parseInt(Integer.java:652)
        at java.base/java.lang.Integer.parseInt(Integer.java:770)
        at io.jaegertracing.internal.clock.SystemClock.getJavaVersion(SystemClock.java:34)
        at io.jaegertracing.internal.clock.SystemClock.<clinit>(SystemClock.java:39)
        ... 27 more
```

It turned out that `SystemClock` is able to deal with GA releases only, this PR adds the support for non-GA builds with respect to `java.version` property as described in https://openjdk.java.net/jeps/223 (section `System properties`).

Thank you.