### PR TITLE
Fix ProbablisticSampler not updating if PerOperation exists

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/RemoteControlledSampler.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/RemoteControlledSampler.java
@@ -93,9 +93,8 @@ public class RemoteControlledSampler implements Sampler {
 
     if (response.getOperationSampling() != null) {
       updatePerOperationSampler(response.getOperationSampling());
-    } else {
-      updateRateLimitingOrProbabilisticSampler(response);
     }
+    updateRateLimitingOrProbabilisticSampler(response);
   }
 
   /**


### PR DESCRIPTION
## Which problem is this PR solving?

This PR should allow `RemoteControlledSampler` to update probabilistic sampling when per operation sampling exists
Resolves https://github.com/jaegertracing/jaeger-client-java/issues/742

## Short description of the changes

This PR just lets `updateRateLimitingOrProbabilisticSampler` run during `updateSampler` even if the response contains per operation sampling