### PR TITLE
Fix dead loop in QueueProcessor

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/reporters/RemoteReporter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/reporters/RemoteReporter.java
@@ -167,7 +167,7 @@ public class RemoteReporter implements Reporter {
    */
   @ToString
   class QueueProcessor implements Runnable {
-    private boolean open = true;
+    private volatile boolean open = true;
     private final Set<Class<?>> commandFailedBefore = new HashSet<Class<?>>();
 
     @Override


### PR DESCRIPTION
<!--
We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Resolves #762
To fix possible thread leak in RemoteReporter.

## Short description of the changes
- This is a common mistake that a variable in multithread context need the "volatile" keyword to keep consistency. In my case, the code above lead to a dead loop, and my app is filled with these dead thread.
