### PR TITLE
Reduce locking in JaegerSpan

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
@@ -181,12 +181,12 @@ public class JaegerSpan implements Span {
   }
 
   private void finishWithDuration(long durationMicros) {
-    if (!durationMicrosUpdater.compareAndSet(this, null, durationMicros)) {
-      log.warn("Span has already been finished; will not be reported again.");
-    } else {
+    if (durationMicrosUpdater.compareAndSet(this, null, durationMicros)) {
       if (context.isSampled()) {
         tracer.reportSpan(this);
       }
+    } else {
+      log.warn("Span has already been finished; will not be reported again.");
     }
   }
 


### PR DESCRIPTION
Looking at profiling results from some of our services, we see lock contention in JaegerSpan methods.
This change reduces locking in JaegerSpan.
It also removes Collections.unmodifiableXXX wrappers around copied collections.

Resolves #792