### PR TITLE
Remove all remaining synchronized implementations of Sampler.sample

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/GuaranteedThroughputSampler.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/samplers/GuaranteedThroughputSampler.java
@@ -33,8 +33,8 @@ import lombok.ToString;
 public final class GuaranteedThroughputSampler implements Sampler {
   public static final String TYPE = "lowerbound";
 
-  private ProbabilisticSampler probabilisticSampler;
-  private RateLimitingSampler lowerBoundSampler;
+  private volatile ProbabilisticSampler probabilisticSampler;
+  private volatile RateLimitingSampler lowerBoundSampler;
   private Map<String, Object> tags;
 
   public GuaranteedThroughputSampler(double samplingRate, double lowerBound) {
@@ -75,7 +75,7 @@ public final class GuaranteedThroughputSampler implements Sampler {
    * @param id The traceId on the span
    */
   @Override
-  public synchronized SamplingStatus sample(String operation, long id) {
+  public SamplingStatus sample(String operation, long id) {
     SamplingStatus probabilisticSamplingStatus = probabilisticSampler.sample(operation, id);
     SamplingStatus lowerBoundSamplingStatus = lowerBoundSampler.sample(operation, id);
 


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes https://github.com/jaegertracing/jaeger-client-java/issues/807 and improves on https://github.com/jaegertracing/jaeger/issues/1729 by not replacing samplers on every update.  Rate limit budgets will only be reset if the operation's lower bound rate limit changes. 

## Short description of the changes
- Remove synchronized on GuaranteedThroughputSampler.sample
    -  use `volatile` fields similar to #609 
- Remove synchronized on PerOperationSampler.sample
    - use `volatile` fields and a ConcurrentHashMap instead
