### PR TITLE
Add ability to filter and defer spans

### DIFF
--- a/jaeger-core/README.md
+++ b/jaeger-core/README.md
@@ -209,6 +209,28 @@ The Logstash configuration might look like this:
         </root>
 ```
 
+### Duration-Based Filtering
+
+When instrumenting a system that generates a large volume of spans (e.g., an interpreter that creates a span
+for every function call, operator, etc.) it can be useful to only report those spans that are involved in
+slow operations. Spans can be filtered if they are below a hard limit while other spans not reported unless a
+parent span exceeds a defer threshold:
+
+```java
+Configuration.ReporterConfiguration reporterConfig = Configuration.ReporterConfiguration.fromEnv()
+    .withFilterSpansUnder(10L)
+    .withDeferSpansUnder(100L);
+
+Configuration configuration = new Configuration("foo")
+    .withReporter(reporterConfig);
+
+Tracer tracer = configuration.getTracer();
+```
+
+This can allow for a significant reduction in the amount of data produced and collected without losing details
+for slow traces, but at the cost of increased memory consumption as spans are temporarily buffered in memory.
+Internal metrics are available to monitor the number of pending spans.
+
 ## Development
 
 Especially in unit tests, it's useful to have tracer that is not connected to tracing backend, but collects

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/metrics/Metrics.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/metrics/Metrics.java
@@ -205,4 +205,25 @@ public class Metrics {
   @Metric(name = "baggage_restrictions_updates", tags = @Tag(key = "result", value = "err"))
   // Number of times baggage restrictions failed to update.
   public Counter baggageRestrictionsUpdateFailure;
+
+  @Metric(name = "deferred_spans_pending")
+  // Number of deferred spans currently pending.
+  public Gauge deferredSpansPending;
+
+  @Metric(name = "filtered_spans")
+  // Number of spans dropped due to short duration.
+  public Counter filteredSpans;
+
+  @Metric(name = "deferred_spans_started")
+  // Number of spans that have been deferred.
+  public Counter deferredSpansStarted;
+
+  @Metric(name = "deferred_spans_finished", tags = @Tag(key = "disposition", value = "dropped"))
+  // Number of deferred spans that were dropped.
+  public Counter deferredSpansDropped;
+
+  @Metric(name = "deferred_spans_finished", tags = @Tag(key = "disposition", value = "sent"))
+  // Number of deferred spans that were sent.
+  public Counter deferredSpansSent;
+
 }

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/reporters/FilteringReporter.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/reporters/FilteringReporter.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2021, The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.jaegertracing.internal.reporters;
+
+import io.jaegertracing.internal.JaegerSpan;
+import io.jaegertracing.internal.JaegerSpanContext;
+import io.jaegertracing.internal.metrics.Metrics;
+import io.jaegertracing.spi.Reporter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * FilteringReporter reduces the number of spans reported by filtering and deferring them. Spans below the
+ * filter threshold are dropped. Spans below the defer threshold are buffered until a parent span exceeds the
+ * defer threshold. If a root span is below the defer threshold it and any buffered child spans are dropped.
+ */
+@ToString
+@Slf4j
+public class FilteringReporter implements Reporter {
+  public static final long DEFAULT_FILTER_SPANS_UNDER_MICROS = 0L;
+  public static final long DEFAULT_DEFER_SPANS_UNDER_MICROS = 0L;
+
+  private final Reporter delegate;
+  private final long filterSpansUnderMicros;
+  private final long deferSpansUnderMicros;
+  private final Metrics metrics;
+
+  private final Map<Long, List<JaegerSpan>> pendingByParent = new ConcurrentHashMap<>();
+  private final LongAdder pendingCount = new LongAdder();
+
+  public FilteringReporter(
+      Reporter delegate, long filterSpansUnderMicros, long deferSpansUnderMicros, Metrics metrics) {
+    this.delegate = delegate;
+    this.filterSpansUnderMicros = filterSpansUnderMicros;
+    this.deferSpansUnderMicros = deferSpansUnderMicros;
+    this.metrics = metrics;
+  }
+
+  @Override
+  public void report(JaegerSpan span) {
+    final JaegerSpanContext context = span.context();
+    final List<JaegerSpan> pendingChildren = pendingByParent.remove(context.getSpanId());
+
+    if (span.getDuration() < filterSpansUnderMicros) {
+      metrics.filteredSpans.inc(1);
+      return;
+    }
+
+    if (span.getDuration() < deferSpansUnderMicros) {
+      defer(span, context, pendingChildren);
+    } else {
+      // report pending if any, then this span
+      if (pendingChildren != null) {
+        pendingChildren.forEach(delegate::report);
+        final int count = pendingChildren.size();
+        pendingCount.add(-1 * count);
+        metrics.deferredSpansPending.update(pendingCount.longValue());
+        metrics.deferredSpansSent.inc(count);
+      }
+      delegate.report(span);
+    }
+  }
+
+  private void defer(final JaegerSpan span, final JaegerSpanContext context,
+      final List<JaegerSpan> pendingChildren) {
+    final long parentId = context.getParentId();
+    final boolean hasParent = parentId != 0;
+    final boolean hasPendingChildren = pendingChildren != null;
+    if (hasParent) {
+      // Defer this span along with any already pending children:
+      pendingByParent.compute(parentId, (id, spans) ->
+        setOrUpdateParentsPendingSpans(hasPendingChildren, pendingChildren, spans)).add(span);
+      pendingCount.increment();
+      metrics.deferredSpansPending.update(pendingCount.longValue());
+      metrics.deferredSpansStarted.inc(1);
+    } else if (hasPendingChildren) {
+      // The current span is a top-level span that does not meet the criteria so all the previously pending
+      // children need to be marked as dropped:
+      final int count = pendingChildren.size();
+      pendingCount.add(-1 * count);
+      metrics.deferredSpansPending.update(pendingCount.longValue());
+      metrics.deferredSpansDropped.inc(count);
+    }
+  }
+
+  /**
+   * This is the remapping function used to update the pendingByParent map. This method returns the list to be
+   * used for all spans pending on a parent span. This method adds any spans pending on the current span to
+   * this list, and then the caller will add the current span.
+   */
+  static List<JaegerSpan> setOrUpdateParentsPendingSpans(final boolean hasPendingChildren,
+      final List<JaegerSpan> pendingOnThisSpan,
+      final List<JaegerSpan> pendingOnParentSpan) {  // visible for testing
+    if (pendingOnParentSpan == null) {
+      // First sibling to be deferred, either promote the existing pending children list or create a new list:
+      return hasPendingChildren ? pendingOnThisSpan : new ArrayList<>(1);
+    }
+    // A list has already been created by a sibling. Copy over this span's pending children if any:
+    if (hasPendingChildren) {
+      pendingOnParentSpan.addAll(pendingOnThisSpan);
+    }
+    return pendingOnParentSpan;
+  }
+
+  @Override
+  public void close() {
+    pendingByParent.values().forEach(pendingSpans -> metrics.deferredSpansDropped.inc(pendingSpans.size()));
+    pendingByParent.clear();
+    delegate.close();
+    pendingCount.reset();
+    metrics.deferredSpansPending.update(0);
+  }
+}

--- a/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/ConfigurationTest.java
@@ -63,6 +63,8 @@ public class ConfigurationTest {
     // Explicitly clear all properties
     System.clearProperty(Configuration.JAEGER_AGENT_HOST);
     System.clearProperty(Configuration.JAEGER_AGENT_PORT);
+    System.clearProperty(Configuration.JAEGER_REPORTER_DEFER_SPANS_UNDER);
+    System.clearProperty(Configuration.JAEGER_REPORTER_FILTER_SPANS_UNDER);
     System.clearProperty(Configuration.JAEGER_REPORTER_LOG_SPANS);
     System.clearProperty(Configuration.JAEGER_REPORTER_MAX_QUEUE_SIZE);
     System.clearProperty(Configuration.JAEGER_REPORTER_FLUSH_INTERVAL);
@@ -125,12 +127,16 @@ public class ConfigurationTest {
     System.setProperty(Configuration.JAEGER_AGENT_PORT, "1234");
     System.setProperty(Configuration.JAEGER_REPORTER_FLUSH_INTERVAL, "500");
     System.setProperty(Configuration.JAEGER_REPORTER_MAX_QUEUE_SIZE, "1000");
+    System.setProperty(Configuration.JAEGER_REPORTER_DEFER_SPANS_UNDER, "2000");
+    System.setProperty(Configuration.JAEGER_REPORTER_FILTER_SPANS_UNDER, "10");
     ReporterConfiguration reporterConfig = ReporterConfiguration.fromEnv();
     assertTrue(reporterConfig.getLogSpans());
     assertEquals("MyHost", reporterConfig.getSenderConfiguration().getAgentHost());
     assertEquals(1234, reporterConfig.getSenderConfiguration().getAgentPort().intValue());
     assertEquals(500, reporterConfig.getFlushIntervalMs().intValue());
     assertEquals(1000, reporterConfig.getMaxQueueSize().intValue());
+    assertEquals(2000, reporterConfig.getDeferSpansUnderMicros().longValue());
+    assertEquals(10, reporterConfig.getFilterSpansUnderMicros().longValue());
   }
 
   @Test
@@ -145,6 +151,20 @@ public class ConfigurationTest {
     System.setProperty(Configuration.JAEGER_REPORTER_LOG_SPANS, "X");
     ReporterConfiguration reporterConfig = ReporterConfiguration.fromEnv();
     assertFalse(reporterConfig.getLogSpans());
+  }
+
+  @Test
+  public void testReporterConfigurationInvalidFilterSpansUnder() {
+    System.setProperty(Configuration.JAEGER_REPORTER_FILTER_SPANS_UNDER, "X");
+    ReporterConfiguration reporterConfig = ReporterConfiguration.fromEnv();
+    assertNull(reporterConfig.getFilterSpansUnderMicros());
+  }
+
+  @Test
+  public void testReporterConfigurationInvalidDeferSpansUnder() {
+    System.setProperty(Configuration.JAEGER_REPORTER_DEFER_SPANS_UNDER, "X");
+    ReporterConfiguration reporterConfig = ReporterConfiguration.fromEnv();
+    assertNull(reporterConfig.getDeferSpansUnderMicros());
   }
 
   @Test

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/reporters/FilteringReporterTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/reporters/FilteringReporterTest.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2021, The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.jaegertracing.internal.reporters;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.jaegertracing.internal.JaegerSpan;
+import io.jaegertracing.internal.JaegerSpanContext;
+import io.jaegertracing.internal.metrics.InMemoryMetricsFactory;
+import io.jaegertracing.internal.metrics.Metrics;
+import io.jaegertracing.spi.Reporter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class FilteringReporterTest {
+  private Reporter reporter;
+  private InMemoryReporter delegate;
+  private final long filterThreshold = 5; // in microseconds
+  private final long deferThreshold = 20; // in microseconds
+  private Metrics metrics;
+  private InMemoryMetricsFactory metricsFactory;
+
+  @Before
+  public void setUp() {
+    metricsFactory = new InMemoryMetricsFactory();
+    metrics = new Metrics(metricsFactory);
+
+    delegate = spy(new InMemoryReporter());
+
+    reporter = new FilteringReporter(delegate, filterThreshold, deferThreshold, metrics);
+  }
+
+  @Test
+  public void testUnfilteredNondeferredSpan() {
+    // Given:
+    JaegerSpan mockSpan = mockSpan(1L, 1000L);
+
+    // When:
+    reporter.report(mockSpan);
+
+    // Then:
+    assertEquals(1, delegate.getSpans().size());
+    assertEquals(mockSpan, delegate.getSpans().get(0));
+    assertMetrics(expect().spansPending(0).spansFiltered(0).spansStarted(0).spansDropped(0).spansSent(0));
+  }
+
+  @Test
+  public void testSpanFiltered() {
+    // Given:
+    JaegerSpan mockSpan = mockSpan(1L, 1L);
+
+    // When:
+    reporter.report(mockSpan);
+
+    // Then:
+    assertTrue(delegate.getSpans().isEmpty());
+    assertMetrics(expect().spansPending(0).spansFiltered(1).spansStarted(0).spansDropped(0).spansSent(0));
+  }
+
+  @Test
+  public void testSpanDeferredThenSent() {
+    // Given:
+    JaegerSpan mockSpan = mockSpan(1L, 100L);
+
+    JaegerSpan mockChildSpan = mockSpan(2L, 1L, 10L);
+
+    // When:
+    reporter.report(mockChildSpan);
+
+    // Then:
+    assertTrue(delegate.getSpans().isEmpty());
+    assertMetrics(expect().spansPending(1).spansFiltered(0).spansStarted(1).spansDropped(0).spansSent(0));
+
+    // When:
+    reporter.report(mockSpan);
+
+    // Then:
+    assertEquals(2, delegate.getSpans().size());
+    assertEquals(mockChildSpan, delegate.getSpans().get(0));
+    assertEquals(mockSpan, delegate.getSpans().get(1));
+    assertMetrics(expect().spansPending(0).spansFiltered(0).spansStarted(1).spansDropped(0).spansSent(1));
+  }
+
+  @Test
+  public void testSpanDeferredThenDropped() {
+    // Given:
+    JaegerSpan mockSpan = mockSpan(1L, 15L);
+    JaegerSpan mockChildSpan = mockSpan(2L, 1L, 10L);
+
+    // When:
+    reporter.report(mockChildSpan);
+
+    // Then:
+    assertTrue(delegate.getSpans().isEmpty());
+    assertMetrics(expect().spansPending(1).spansFiltered(0).spansStarted(1).spansDropped(0).spansSent(0));
+
+    // When:
+    reporter.report(mockSpan);
+
+    // Then:
+    assertEquals(0, delegate.getSpans().size());
+    assertMetrics(expect().spansPending(0).spansFiltered(0).spansStarted(1).spansDropped(1).spansSent(0));
+  }
+
+  @Test
+  public void testDeferredGrandchildren() {
+    // Given:
+    final JaegerSpan rootSpan = mockSpan(1L, 5000L);
+    final JaegerSpan firstChild = mockSpan(10L, 1L, 19L);
+    final JaegerSpan firstGrandchild = mockSpan(11L, 10L, 9L);
+    final JaegerSpan secondChild = mockSpan(20L, 1L, 19L);
+    final JaegerSpan secondGrandchild = mockSpan(21L, 20L, 9L);
+
+    // When:
+    reporter.report(firstGrandchild);
+    reporter.report(secondGrandchild);
+    reporter.report(firstChild);
+    reporter.report(secondChild);
+    reporter.report(rootSpan);
+
+    // Then:
+    assertEquals(5, delegate.getSpans().size());
+    assertEquals(firstGrandchild, delegate.getSpans().get(0));
+    assertEquals(firstChild, delegate.getSpans().get(1));
+    assertEquals(secondGrandchild, delegate.getSpans().get(2));
+    assertEquals(secondChild, delegate.getSpans().get(3));
+    assertEquals(rootSpan, delegate.getSpans().get(4));
+    assertMetrics(expect().spansPending(0).spansFiltered(0).spansStarted(4).spansDropped(0).spansSent(4));
+  }
+
+  @Test
+  public void testClose() {
+    // Given:
+    final JaegerSpan deferredSpan = mockSpan(2L, 1L, 15L);
+
+    // When:
+    reporter.report(deferredSpan);
+    reporter.close();
+
+    // Then:
+    verify(delegate).close();
+    assertMetrics(expect().spansPending(0).spansFiltered(0).spansStarted(1).spansDropped(1).spansSent(0));
+  }
+
+  @Test
+  public void testSetOrUpdateParentsPendingSpans_noChildren_firstSibling() {
+    // Given:
+    final boolean hasPendingChildren = false;
+    final List<JaegerSpan> pendingOnThisSpan = null;
+    final List<JaegerSpan> pendingOnParentSpan = null;
+
+    // When:
+    final List<JaegerSpan> spans = FilteringReporter.setOrUpdateParentsPendingSpans(hasPendingChildren,
+        pendingOnThisSpan, pendingOnParentSpan);
+
+    // Then:
+    assertNotNull("A new list was not created", spans);
+    assertTrue("New list should be empty", spans.isEmpty());
+  }
+
+  @Test
+  public void testSetOrUpdateParentsPendingSpans_hasChildren_firstSibling() {
+    // Given:
+    final boolean hasPendingChildren = true;
+    final List<JaegerSpan> pendingOnThisSpan = new ArrayList<>(1);
+    final JaegerSpan pendingChild = mockSpan(10, 1, 1);
+    pendingOnThisSpan.add(pendingChild);
+    final List<JaegerSpan> pendingOnParentSpan = null;
+
+    // When:
+    final List<JaegerSpan> spans = FilteringReporter.setOrUpdateParentsPendingSpans(hasPendingChildren,
+        pendingOnThisSpan, pendingOnParentSpan);
+
+    // Then:
+    assertEquals("Existing pending children list not promoted", pendingOnThisSpan, spans);
+    assertEquals("Pending child not found", pendingChild, spans.get(0));
+  }
+
+  @Test
+  public void testSetOrUpdateParentsPendingSpans_noChildren_laterSibling() {
+    // Given:
+    final boolean hasPendingChildren = false;
+    final List<JaegerSpan> pendingOnThisSpan = null;
+    final List<JaegerSpan> pendingOnParentSpan = new ArrayList<>(1);
+    final JaegerSpan pending = mockSpan(20, 1, 1);
+    pendingOnParentSpan.add(pending);
+
+    // When:
+    final List<JaegerSpan> spans = FilteringReporter.setOrUpdateParentsPendingSpans(hasPendingChildren,
+        pendingOnThisSpan, pendingOnParentSpan);
+
+    // Then:
+    assertEquals("Existing list not reused", pendingOnParentSpan, spans);
+    assertEquals("Pending span not found", pending, spans.get(0));
+  }
+
+  @Test
+  public void testSetOrUpdateParentsPendingSpans_hasChildren_laterSibling() {
+    // Given:
+    final boolean hasPendingChildren = true;
+    final List<JaegerSpan> pendingOnThisSpan = new ArrayList<>(1);
+    final JaegerSpan pendingChild = mockSpan(10, 1, 1);
+    pendingOnThisSpan.add(pendingChild);
+    final List<JaegerSpan> pendingOnParentSpan = new ArrayList<>(1);
+    final JaegerSpan pending = mockSpan(20, 1, 1);
+    pendingOnParentSpan.add(pending);
+
+    // When:
+    final List<JaegerSpan> spans = FilteringReporter.setOrUpdateParentsPendingSpans(hasPendingChildren,
+        pendingOnThisSpan, pendingOnParentSpan);
+
+    // Then:
+    assertEquals("Existing list not reused", pendingOnParentSpan, spans);
+    assertEquals("Pending span not found", pending, spans.get(0));
+    assertEquals("Pending child not copied over", pendingChild, spans.get(1));
+  }
+
+  private JaegerSpan mockSpan(long spanId, long duration) {
+    return mockSpan(spanId, 0L, duration);
+  }
+
+  private JaegerSpan mockSpan(long spanId, long parentSpanId, long duration) {
+    JaegerSpan mockChildSpan = mock(JaegerSpan.class);
+    JaegerSpanContext mockChildContext = mock(JaegerSpanContext.class);
+    when(mockChildContext.getSpanId()).thenReturn(spanId);
+    when(mockChildContext.getParentId()).thenReturn(parentSpanId);
+    when(mockChildSpan.context()).thenReturn(mockChildContext);
+    when(mockChildSpan.getDuration()).thenReturn(duration);
+    return mockChildSpan;
+  }
+
+  private void assertMetrics(final ExpectedMetrics expectedMetrics) {
+    if (expectedMetrics.getSpansPending() != null) {
+      assertEquals("incorrect metric for spans pending",
+          expectedMetrics.getSpansPending().longValue(),
+          metricsFactory.getGauge("jaeger_tracer_deferred_spans_pending", ""));
+    }
+    if (expectedMetrics.getSpansFiltered() != null) {
+      assertEquals("incorrect metric for spans filtered",
+          expectedMetrics.getSpansFiltered().longValue(),
+          metricsFactory.getCounter("jaeger_tracer_filtered_spans", ""));
+    }
+    if (expectedMetrics.getSpansStarted() != null) {
+      assertEquals("incorrect metric for spans started",
+          expectedMetrics.getSpansStarted().longValue(),
+          metricsFactory.getCounter("jaeger_tracer_deferred_spans_started", ""));
+    }
+    if (expectedMetrics.getSpansDropped() != null) {
+      assertEquals("incorrect metric for spans dropped",
+          expectedMetrics.getSpansDropped().longValue(),
+          metricsFactory.getCounter("jaeger_tracer_deferred_spans_finished", "disposition=dropped"));
+    }
+    if (expectedMetrics.getSpansSent() != null) {
+      assertEquals("incorrect metric for spans sent",
+          expectedMetrics.getSpansSent().longValue(),
+          metricsFactory.getCounter("jaeger_tracer_deferred_spans_finished", "disposition=sent"));
+    }
+  }
+
+  private static final class ExpectedMetrics {
+    private Long spansPending;
+    private Long spansFiltered;
+    private Long spansStarted;
+    private Long spansDropped;
+    private Long spansSent;
+
+    public ExpectedMetrics spansPending(long expect) {
+      spansPending = expect;
+      return this;
+    }
+
+    public Long getSpansPending() {
+      return spansPending;
+    }
+
+    public ExpectedMetrics spansFiltered(long expect) {
+      spansFiltered = expect;
+      return this;
+    }
+
+    public Long getSpansFiltered() {
+      return spansFiltered;
+    }
+
+    public ExpectedMetrics spansStarted(long expect) {
+      spansStarted = expect;
+      return this;
+    }
+
+    public Long getSpansStarted() {
+      return spansStarted;
+    }
+
+    public ExpectedMetrics spansDropped(long expect) {
+      spansDropped = expect;
+      return this;
+    }
+
+    public Long getSpansDropped() {
+      return spansDropped;
+    }
+
+    public ExpectedMetrics spansSent(long expect) {
+      spansSent = expect;
+      return this;
+    }
+
+    public Long getSpansSent() {
+      return spansSent;
+    }
+  }
+
+  private static ExpectedMetrics expect() {
+    return new ExpectedMetrics();
+  }
+}

--- a/jaeger-micrometer/src/test/java/io/jaegertracing/micrometer/MicrometerTest.java
+++ b/jaeger-micrometer/src/test/java/io/jaegertracing/micrometer/MicrometerTest.java
@@ -65,6 +65,10 @@ public class MicrometerTest {
     expectedMetricCounts.put("jaeger_tracer_traces", 4L);
     expectedMetricCounts.put("jaeger_tracer_span_context_decoding_errors", 1L);
     expectedMetricCounts.put("jaeger_tracer_reporter_queue_length", 1L);
+    expectedMetricCounts.put("jaeger_tracer_deferred_spans_pending", 1L);
+    expectedMetricCounts.put("jaeger_tracer_deferred_spans_finished", 2L);
+    expectedMetricCounts.put("jaeger_tracer_deferred_spans_started", 1L);
+    expectedMetricCounts.put("jaeger_tracer_filtered_spans", 1L);
   }
 
 
@@ -129,8 +133,9 @@ public class MicrometerTest {
             .withMetrics(metrics)
             .build();
 
-    // This is a gauge, so it needs to be non-zero to come back from prometheus
+    // These are gauges, so they need to be non-zero to come back from prometheus
     metrics.reporterQueueLength.update(1);
+    metrics.deferredSpansPending.update(1);
 
     List<Meter> meters = new ArrayList<>(prometheusRegistry.getMeters());
     Map<String, Long> metricCounts = meters


### PR DESCRIPTION
Signed-off-by: Edward Bross <edward.bross@appian.com>

## Which problem is this PR solving?
- Resolves #815

## Short description of the changes
- adds the ability to reduce the number of spans reported by setting a filter and a defer threshold
- implemented via a new `FilteringReporter` that handles the filtering and buffering logic before forwarding spans to a delegate
