### PR TITLE
Restore support for setting null as a tag value (Resolves #823)

### DIFF
--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
@@ -68,7 +68,7 @@ public class JaegerSpan implements Span {
     this.startTimeMicroseconds = startTimeMicroseconds;
     this.startTimeNanoTicks = startTimeNanoTicks;
     this.computeDurationViaNanoTicks = computeDurationViaNanoTicks;
-    this.tags = new ConcurrentHashMap<String, Object>();
+    this.tags = new HashMap<>();
     this.references = references != null ? new ArrayList<Reference>(references) : null;
 
     // Handle SAMPLING_PRIORITY tag first, as this influences whether setTagAsObject actually
@@ -110,8 +110,8 @@ public class JaegerSpan implements Span {
     return Collections.unmodifiableList(references);
   }
 
-  public Map<String, Object> getTags() {
-    return new HashMap<String, Object>(tags);
+  public synchronized Map<String, Object> getTags() {
+    return new HashMap<>(tags);
   }
 
   @Override

--- a/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
+++ b/jaeger-core/src/main/java/io/jaegertracing/internal/JaegerSpan.java
@@ -68,7 +68,7 @@ public class JaegerSpan implements Span {
     this.startTimeMicroseconds = startTimeMicroseconds;
     this.startTimeNanoTicks = startTimeNanoTicks;
     this.computeDurationViaNanoTicks = computeDurationViaNanoTicks;
-    this.tags = new HashMap<>();
+    this.tags = new ConcurrentHashMap<>();
     this.references = references != null ? new ArrayList<Reference>(references) : null;
 
     // Handle SAMPLING_PRIORITY tag first, as this influences whether setTagAsObject actually
@@ -110,7 +110,7 @@ public class JaegerSpan implements Span {
     return Collections.unmodifiableList(references);
   }
 
-  public synchronized Map<String, Object> getTags() {
+  public Map<String, Object> getTags() {
     return new HashMap<>(tags);
   }
 
@@ -225,7 +225,7 @@ public class JaegerSpan implements Span {
     }
 
     if (context.isSampled()) {
-      tags.put(key, value);
+      tags.put(key, value == null ? "null" : value);
     }
 
     return this;

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSpanTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSpanTest.java
@@ -125,6 +125,15 @@ public class JaegerSpanTest {
   }
 
   @Test
+  public void testSetNullTag() {
+    String key = "tag.key";
+
+    jaegerSpan.setTag(key, (String)null);
+    assertNull(jaegerSpan.getTags().get(key));
+    assertTrue(jaegerSpan.getTags().containsKey(key));
+  }
+
+  @Test
   public void testSetBooleanTag() {
     Boolean expected = true;
     String key = "tag.key";

--- a/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSpanTest.java
+++ b/jaeger-core/src/test/java/io/jaegertracing/internal/JaegerSpanTest.java
@@ -129,8 +129,7 @@ public class JaegerSpanTest {
     String key = "tag.key";
 
     jaegerSpan.setTag(key, (String)null);
-    assertNull(jaegerSpan.getTags().get(key));
-    assertTrue(jaegerSpan.getTags().containsKey(key));
+    assertEquals("null", jaegerSpan.getTags().get(key));
   }
 
   @Test


### PR DESCRIPTION
To maintain backwards compatibility, we better restore the ability to set null as a tag value.
This change reverts the use of `ConcurrentHashMap` for the tags map in `JaegerSpan` back to `HashMap`, as `HashMap` supports null values while `ConcurrentHashMap` does not.